### PR TITLE
Fix React Query imports and typing issue

### DIFF
--- a/components/InformePDF.tsx
+++ b/components/InformePDF.tsx
@@ -78,7 +78,8 @@ const styles = StyleSheet.create({
     paddingBottom: 5,
   },
   table: {
-    display: 'table',
+    /* display: 'table' causes a type error with @react-pdf styles */
+    // display: 'table', // not supported by type definitions
     width: 'auto',
     borderStyle: 'solid',
     borderWidth: 1,

--- a/components/ItemTable.tsx
+++ b/components/ItemTable.tsx
@@ -3,9 +3,10 @@ import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 
 export function ItemTable() {
-  const { data, isLoading, error } = useQuery(['items'], () =>
-    axios.get('/api/items').then(res => res.data)
-  );
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['items'],
+    queryFn: () => axios.get('/api/items').then(res => res.data),
+  });
 
   if (isLoading) return <p>Cargando items…</p>;
   if (error) return <p>Error al cargar items.</p>;

--- a/components/RequestForm.tsx
+++ b/components/RequestForm.tsx
@@ -2,7 +2,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { SolicitudCreateSchema } from "../lib/zodSchemas";
 import axios from "axios";
-import { useQueryClient } from "react-query";
+import { useQueryClient } from '@tanstack/react-query';
 
 export function RequestForm({ items }: { items: any[] }) {
   const qc = useQueryClient();
@@ -12,7 +12,7 @@ export function RequestForm({ items }: { items: any[] }) {
 
   const onSubmit = async (data: any) => {
     await axios.post("/api/solicitudes", data);
-    qc.invalidateQueries("solicitudes");
+    qc.invalidateQueries({ queryKey: ['solicitudes'] });
   };
 
   return (

--- a/pages/departamentos/index.tsx
+++ b/pages/departamentos/index.tsx
@@ -1,11 +1,12 @@
-import { useQuery } from "react-query";
+import { useQuery } from '@tanstack/react-query';
 import axios from "axios";
 import { DepartmentForm } from "../../components/DepartmentForm";
 
 export default function DeptPage() {
-  const { data, refetch } = useQuery("deps", () =>
-    axios.get("/api/departamentos").then((r) => r.data)
-  );
+  const { data, refetch } = useQuery({
+    queryKey: ['deps'],
+    queryFn: () => axios.get('/api/departamentos').then((r) => r.data),
+  });
 
   return (
     <div>

--- a/pages/solicitudes/index.tsx
+++ b/pages/solicitudes/index.tsx
@@ -1,14 +1,16 @@
-import { useQuery } from "react-query";
+import { useQuery } from '@tanstack/react-query';
 import axios from "axios";
 import { RequestForm } from "../../components/RequestForm";
 
 export default function SolicitudesPage() {
-  const { data: items } = useQuery("items", () =>
-    axios.get("/api/items").then((r) => r.data)
-  );
-  const { data: sols, refetch } = useQuery("solicitudes", () =>
-    axios.get("/api/solicitudes").then((r) => r.data)
-  );
+  const { data: items } = useQuery({
+    queryKey: ['items'],
+    queryFn: () => axios.get('/api/items').then((r) => r.data),
+  });
+  const { data: sols, refetch } = useQuery({
+    queryKey: ['solicitudes'],
+    queryFn: () => axios.get('/api/solicitudes').then((r) => r.data),
+  });
 
   const approve = async (id: number, estado: string) => {
     await axios.patch(`/api/solicitudes/${id}`, { estado });


### PR DESCRIPTION
## Summary
- fix outdated `react-query` imports to use `@tanstack/react-query`
- adjust `useQuery` calls to new API
- fix invalid `display: 'table'` style in `InformePDF`

## Testing
- `npm run build` *(fails: Could not find a declaration file for module 'nodemailer', then other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68595e42f0088327928ae35ccf119bba