### PR TITLE
Update README and add env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+DATABASE_URL="mysql://user:pass@localhost:3306/dbname"
+NEXTAUTH_SECRET="changeme"
+
+# SMTP credentials
+SMTP_HOST=smtp.example.com
+SMTP_PORT=2525
+SMTP_USER=your-email@example.com
+SMTP_PASS=your-smtp-pass
+
+# Sender email
+EMAIL_FROM="your-email@example.com"
+
+# Base application URL
+NEXTAUTH_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-"node_modules/" 
-"*.zip" 
-"node_modules/" 
-"*.zip" 
-"node_modules/" 
-"*.zip" 
+node_modules/
+*.zip
+.env
+
+# local env file used by vs code or other tools
+.env.local

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
-# inventario-unphu
-# npm run dev Esto corre el entorno de produccion
-# npx prisma studio Este corre la DBA
+# Inventario UNPHU
+
+Este proyecto utiliza Next.js y Prisma. Sigue los pasos a continuacion para configurar el entorno de desarrollo.
+
+## Configuracion del entorno
+
+1. Instala las dependencias:
+   ```bash
+   npm install
+   ```
+2. Genera el cliente de Prisma:
+   ```bash
+   npx prisma generate
+   ```
+3. Ejecuta las migraciones (si existen) y levanta el servidor de desarrollo:
+   ```bash
+   npx prisma migrate dev # opcional si hay migraciones pendientes
+   npm run dev
+   ```
+
+## Variables de entorno
+
+Copia `.env.example` a `.env` y ajusta los valores antes de iniciar la aplicacion.


### PR DESCRIPTION
## Summary
- update documentation with setup steps
- add example env file
- ignore env files and node_modules

## Testing
- `npm run build` *(fails: Property 'options' does not exist on type 'EventTarget & (HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement)')*

------
https://chatgpt.com/codex/tasks/task_e_68597b2b47b483278199d2603f6af1fd