### PR TITLE
Add toast notifications with row highlight

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@
 import { SessionProvider } from 'next-auth/react'
 import type { AppProps } from 'next/app'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Toaster } from 'react-hot-toast'
 import '../styles/global.css'
 
 // 1) Crea un QueryClient de React Query
@@ -18,6 +19,7 @@ export default function App({
       <QueryClientProvider client={queryClient}>
         {/* 4) Renderiza la página */}
         <Component {...pageProps} />
+        <Toaster position="top-right" />
       </QueryClientProvider>
     </SessionProvider>
   )

--- a/pages/admin/departments.tsx
+++ b/pages/admin/departments.tsx
@@ -4,6 +4,7 @@ import { getSession } from 'next-auth/react'
 import Layout from '../../components/Layout'
 import { prisma } from '../../lib/prisma'
 import { useState } from 'react'
+import { toast } from 'react-hot-toast'
 
 type Usuario = { id: number; nombre: string; apellido: string }
 type Departamento = {
@@ -22,6 +23,7 @@ export default function AdminDepartments({ departamentos, usuarios }: Props) {
   const [list, setList] = useState<Departamento[]>(departamentos)
   const [showModal, setShowModal] = useState(false)
   const [editing, setEditing] = useState<Departamento | null>(null)
+  const [highlightId, setHighlightId] = useState<number | null>(null)
   const [form, setForm] = useState({
     nombre: '',
     descripcion: '',
@@ -93,8 +95,12 @@ export default function AdminDepartments({ departamentos, usuarios }: Props) {
         setList(l => [...l, data])
       }
       setShowModal(false)
+      toast.success('Guardado correctamente')
+      setHighlightId(data.id)
+      setTimeout(() => setHighlightId(null), 2000)
     } catch (err: any) {
       setError(err.message)
+      toast.error(err.message)
     } finally {
       setLoading(false)
     }
@@ -183,7 +189,7 @@ export default function AdminDepartments({ departamentos, usuarios }: Props) {
           </thead>
           <tbody>
             {list.map(d => (
-              <tr key={d.id}>
+              <tr key={d.id} className={highlightId === d.id ? 'row-highlight' : ''}>
                 <td>{d.nombre}</td>
                 <td>{d.descripcion}</td>
                 <td>

--- a/pages/admin/items.tsx
+++ b/pages/admin/items.tsx
@@ -3,6 +3,7 @@ import { GetServerSideProps } from 'next'
 import { getSession } from 'next-auth/react'
 import Layout from '../../components/Layout'
 import { useState } from 'react'
+import { toast } from 'react-hot-toast'
 
 type Item = {
   id: number
@@ -32,6 +33,7 @@ export default function AdminItems({
 
   const [showModal, setShowModal] = useState(false)
   const [editing, setEditing] = useState<Item | null>(null)
+  const [highlightId, setHighlightId] = useState<number | null>(null)
   const [form, setForm] = useState({
     nombre: '',
     descripcion: '',
@@ -86,7 +88,9 @@ export default function AdminItems({
     let deptId: number
     if (form.departamentoId === 'new') {
       if (!form.newDeptName.trim()) {
-        setError('Debe indicar nombre de nuevo departamento')
+        const msg = 'Debe indicar nombre de nuevo departamento'
+        setError(msg)
+        toast.error(msg)
         setLoading(false)
         return
       }
@@ -98,7 +102,9 @@ export default function AdminItems({
         body: JSON.stringify({ nombre: form.newDeptName.trim() }),
       })
       if (!resDept.ok) {
-        setError('Error al crear departamento')
+        const msg = 'Error al crear departamento'
+        setError(msg)
+        toast.error(msg)
         setLoading(false)
         return
       }
@@ -131,14 +137,18 @@ export default function AdminItems({
     try {
       data = JSON.parse(text)
     } catch {
-      setError(`Error en servidor: ${res.status}`)
+      const msg = `Error en servidor: ${res.status}`
+      setError(msg)
+      toast.error(msg)
       setLoading(false)
       return
     }
 
     setLoading(false)
     if (!res.ok) {
-      setError((data as any).message || 'Error al guardar equipo')
+      const msg = (data as any).message || 'Error al guardar equipo'
+      setError(msg)
+      toast.error(msg)
     } else {
       if (editing) {
         setList(l => l.map(i => i.id === data.id ? data : i))
@@ -146,6 +156,9 @@ export default function AdminItems({
         setList(l => [data, ...l])
       }
       setShowModal(false)
+      toast.success('Guardado correctamente')
+      setHighlightId(data.id)
+      setTimeout(() => setHighlightId(null), 2000)
     }
   }
 
@@ -260,7 +273,7 @@ export default function AdminItems({
           </thead>
           <tbody>
             {list.map(i => (
-              <tr key={i.id}>
+              <tr key={i.id} className={highlightId === i.id ? 'row-highlight' : ''}>
                 <td>{i.nombre}</td>
                 <td>{i.cantidadDisponible}</td>
                 <td>{i.cantidadTotal}</td>

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -3,6 +3,7 @@ import { GetServerSideProps } from 'next'
 import { getSession } from 'next-auth/react'
 import Layout from '../../components/Layout'
 import { useState } from 'react'
+import { toast } from 'react-hot-toast'
 
 type User = {
   id: number
@@ -19,6 +20,7 @@ export default function AdminUsers({ users }: Props) {
   const [list, setList] = useState<User[]>(users)
   const [showModal, setShowModal] = useState(false)
   const [editing, setEditing] = useState<User | null>(null)
+  const [highlightId, setHighlightId] = useState<number | null>(null)
   const [form, setForm] = useState({
     matricula: '',
     nombre: '',
@@ -102,14 +104,18 @@ export default function AdminUsers({ users }: Props) {
     try {
       data = JSON.parse(text)
     } catch {
-      setError(`Error en servidor: ${res.status}`)
+      const msg = `Error en servidor: ${res.status}`
+      setError(msg)
+      toast.error(msg)
       setLoading(false)
       return
     }
 
     setLoading(false)
     if (!res.ok) {
-      setError(data.message || 'Error al guardar usuario')
+      const msg = data.message || 'Error al guardar usuario'
+      setError(msg)
+      toast.error(msg)
     } else {
       if (isEdit) {
         setList(l => l.map(u => (u.id === data.id ? data : u)))
@@ -117,6 +123,9 @@ export default function AdminUsers({ users }: Props) {
         setList(l => [data, ...l])
       }
       setShowModal(false)
+      toast.success('Guardado correctamente')
+      setHighlightId(data.id)
+      setTimeout(() => setHighlightId(null), 2000)
     }
   }
 
@@ -145,7 +154,7 @@ export default function AdminUsers({ users }: Props) {
           </thead>
           <tbody>
             {list.map(u => (
-              <tr key={u.id}>
+              <tr key={u.id} className={highlightId === u.id ? 'row-highlight' : ''}>
                 <td>{u.matricula}</td>
                 <td>{u.nombre} {u.apellido}</td>
                 <td>{u.email}</td>

--- a/styles/global.css
+++ b/styles/global.css
@@ -274,6 +274,19 @@ nav {
   transform: translateY(-2px);
 }
 
+/* Animación para resaltar filas actualizadas */
+.row-highlight td {
+  animation: row-highlight 2s ease-out;
+}
+@keyframes row-highlight {
+  from {
+    background-color: #fffbdd;
+  }
+  to {
+    background-color: var(--surface);
+  }
+}
+
 /* ==========================================================================
   10) MODALES & FORMULARIOS
    ========================================================================== */


### PR DESCRIPTION
## Summary
- integrate `react-hot-toast` Toaster app-wide
- show toast messages after saves in admin pages
- highlight modified table rows briefly
- add row highlight animation styles

## Testing
- `npm run build` *(fails: Cannot find module '@/components/InformePDF')*

------
https://chatgpt.com/codex/tasks/task_e_685996581eb48327a6014d17348015aa