### PR TITLE
Update query parameter for solicitudes filter

### DIFF
--- a/pages/mis-solicitudes.tsx
+++ b/pages/mis-solicitudes.tsx
@@ -27,7 +27,7 @@ export default function MisSolicitudes() {
   useEffect(() => {
     setLoading(true)
     const params = new URLSearchParams()
-    if (search)  params.set('search', search)
+    if (search)  params.set('q', search)
     if (estado)  params.set('estado', estado)
 
     fetch(`/api/solicitudes?${params.toString()}`, { credentials: 'include' })


### PR DESCRIPTION
## Summary
- send query parameter `q` instead of `search` when requesting `api/solicitudes`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685abdcbc3188327a364978d38199f49