### PR TITLE
Implement item deletion in admin UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+/.next
 *.zip
 .env
 

--- a/pages/admin/items.tsx
+++ b/pages/admin/items.tsx
@@ -162,6 +162,24 @@ export default function AdminItems({
     }
   }
 
+  const handleDelete = async (id: number) => {
+    try {
+      const res = await fetch(`/api/admin/items/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      })
+      if (!res.ok) {
+        const msg = `Error ${res.status} al eliminar`
+        toast.error(msg)
+        return
+      }
+      setList(l => l.filter(i => i.id !== id))
+      toast.success('Equipo eliminado')
+    } catch (err: any) {
+      toast.error(err.message || 'Error al eliminar equipo')
+    }
+  }
+
   return (
     <Layout>
       <section className="app-container header-flex">
@@ -283,6 +301,14 @@ export default function AdminItems({
                     onClick={() => openEdit(i)}
                   >
                     Editar
+                  </button>
+                  {' '}
+                  <button
+                    className="btn btn-secondary btn-small"
+                    onClick={() => handleDelete(i.id)}
+                    style={{ marginLeft: '0.5rem' }}
+                  >
+                    Eliminar
                   </button>
                 </td>
               </tr>


### PR DESCRIPTION
## Summary
- allow admins to delete equipment
- show success/error notifications
- ignore `.next` build output

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685ac49114cc83278e5402ce493a15cd