### PR TITLE
Add audit logs for admin modifications

### DIFF
--- a/pages/api/solicitudes/[id].ts
+++ b/pages/api/solicitudes/[id].ts
@@ -3,6 +3,7 @@ import { prisma } from "../../../lib/prisma";
 import { SolicitudUpdateSchema } from "../../../lib/zodSchemas";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "../auth/[...nextauth]";
+import { getToken } from "next-auth/jwt";
 import { sendStatusEmail } from "../../../lib/mailer";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -10,14 +11,32 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (!session || (session.user as any).role !== "ADMIN")
     return res.status(403).json({ error: "Solo admin" });
 
+  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+  const actorId = Number(token?.sub);
+
   try {
     const { id } = req.query;
     if (req.method === "PATCH") {
       const upd = SolicitudUpdateSchema.parse(req.body);
+      const before = await prisma.solicitud.findUnique({
+        where: { id: Number(id) },
+        select: { estado: true }
+      });
+
       const sol = await prisma.solicitud.update({
         where: { id: Number(id) },
         data: upd,
         include: { usuario: true, item: true },
+      });
+
+      await prisma.auditLog.create({
+        data: {
+          userId: actorId,
+          action: 'EDITAR',
+          entity: 'Solicitud',
+          entityId: Number(id),
+          changes: { antes: before, despues: upd }
+        }
       });
 
       // enviar correo al solicitante


### PR DESCRIPTION
## Summary
- log audit entries on admin user updates and deletions
- track item edits/deletes in audit log
- record department edits/deletes via admin APIs
- log request status changes and deletions in audit log

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ad19b06688327be6152de39f12b9c