### PR TITLE
Add admin request filters

### DIFF
--- a/pages/admin/requests.tsx
+++ b/pages/admin/requests.tsx
@@ -18,10 +18,20 @@ export default function AdminRequestsPage() {
   const [solicitudes, setSolicitudes] = useState<Solicitud[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string|null>(null)
+  const [entidadId, setEntidadId] = useState('')
+  const [fecha, setFecha] = useState('')
+  const [usuario, setUsuario] = useState('')
+  const [item, setItem] = useState('')
 
-  // 1) Carga inicial
+  // 1) Carga con filtros
   useEffect(() => {
-    fetch('/api/admin/requests', { credentials: 'include' })
+    setLoading(true)
+    const params = new URLSearchParams()
+    if (entidadId) params.set('entidadId', entidadId)
+    if (fecha)     params.set('fecha', fecha)
+    if (usuario)   params.set('usuario', usuario)
+    if (item)      params.set('item', item)
+    fetch(`/api/admin/requests?${params.toString()}`, { credentials: 'include' })
       .then((res) => {
         if (!res.ok) throw new Error(`Error ${res.status}`)
         return res.json()
@@ -29,7 +39,7 @@ export default function AdminRequestsPage() {
       .then((data: Solicitud[]) => setSolicitudes(data))
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false))
-  }, [])
+  }, [entidadId, fecha, usuario, item])
 
   // 2) Aprobar/Rechazar con comentario
   const handleUpdate = async (
@@ -87,6 +97,31 @@ export default function AdminRequestsPage() {
     <Layout>
       <section className="app-container">
         <h2>Revisión de Solicitudes</h2>
+        <div style={{ display: 'flex', gap: '.5rem', marginBottom: '1rem' }}>
+          <input
+            type="number"
+            placeholder="Entidad ID"
+            value={entidadId}
+            onChange={e => setEntidadId(e.target.value)}
+          />
+          <input
+            type="date"
+            value={fecha}
+            onChange={e => setFecha(e.target.value)}
+          />
+          <input
+            type="text"
+            placeholder="Usuario"
+            value={usuario}
+            onChange={e => setUsuario(e.target.value)}
+          />
+          <input
+            type="text"
+            placeholder="Equipo"
+            value={item}
+            onChange={e => setItem(e.target.value)}
+          />
+        </div>
         <table className="table-minimal">
           <thead>
             <tr>

--- a/pages/api/admin/requests/index.ts
+++ b/pages/api/admin/requests/index.ts
@@ -11,8 +11,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   if (req.method === 'GET') {
     // filtros
-    const q      = Array.isArray(req.query.q)      ? req.query.q[0]      : req.query.q
+    const q      = Array.isArray(req.query.q) ? req.query.q[0] : req.query.q
     const estado = Array.isArray(req.query.estado) ? req.query.estado[0] : req.query.estado
+    const entidadIdRaw = Array.isArray(req.query.entidadId) ? req.query.entidadId[0] : req.query.entidadId
+    const fechaRaw     = Array.isArray(req.query.fecha)     ? req.query.fecha[0]     : req.query.fecha
+    const usuarioRaw   = Array.isArray(req.query.usuario)   ? req.query.usuario[0]   : req.query.usuario
+    const itemRaw      = Array.isArray(req.query.item)      ? req.query.item[0]      : req.query.item
 
     // baseWhere según rol
     const baseWhere = role === 'ADMIN'
@@ -23,6 +27,31 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const and: any[] = []
     if (q)      and.push({ item: { nombre: { contains: q, mode: 'insensitive' } } })
     if (estado) and.push({ estado })
+    if (entidadIdRaw) {
+      const id = Number(entidadIdRaw)
+      if (!isNaN(id)) and.push({ id })
+    }
+    if (fechaRaw) {
+      const date = new Date(fechaRaw)
+      if (!isNaN(date.getTime())) {
+        const next = new Date(date)
+        next.setDate(date.getDate() + 1)
+        and.push({ fechaSolicitud: { gte: date, lt: next } })
+      }
+    }
+    if (usuarioRaw) {
+      and.push({
+        usuario: {
+          OR: [
+            { nombre: { contains: usuarioRaw, mode: 'insensitive' } },
+            { apellido: { contains: usuarioRaw, mode: 'insensitive' } }
+          ]
+        }
+      })
+    }
+    if (itemRaw) {
+      and.push({ item: { nombre: { contains: itemRaw, mode: 'insensitive' } } })
+    }
 
     const where = Object.keys(baseWhere).length
       ? { AND: [ baseWhere, ...and ] }


### PR DESCRIPTION
## Summary
- add filter parameters to the admin requests API
- implement filter inputs on the admin requests page

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad62b80648327ae7e874a11140894