### PR TITLE
Remove Prisma filter modes

### DIFF
--- a/pages/api/admin/requests/index.ts
+++ b/pages/api/admin/requests/index.ts
@@ -25,7 +25,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     // condiciones extras
     const and: any[] = []
-    if (q)      and.push({ item: { nombre: { contains: q, mode: 'insensitive' } } })
+    if (q)      and.push({ item: { nombre: { contains: q } } })
     if (estado) and.push({ estado })
     if (entidadIdRaw) {
       const id = Number(entidadIdRaw)
@@ -43,14 +43,14 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       and.push({
         usuario: {
           OR: [
-            { nombre: { contains: usuarioRaw, mode: 'insensitive' } },
-            { apellido: { contains: usuarioRaw, mode: 'insensitive' } }
+            { nombre: { contains: usuarioRaw } },
+            { apellido: { contains: usuarioRaw } }
           ]
         }
       })
     }
     if (itemRaw) {
-      and.push({ item: { nombre: { contains: itemRaw, mode: 'insensitive' } } })
+      and.push({ item: { nombre: { contains: itemRaw } } })
     }
 
     const where = Object.keys(baseWhere).length

--- a/pages/api/solicitudes/index.ts
+++ b/pages/api/solicitudes/index.ts
@@ -29,7 +29,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     // 5) Armo condiciones adicionales
     const and: any[] = []
-    if (q)      and.push({ item: { nombre: { contains: q, mode: 'insensitive' } } })
+    if (q)      and.push({ item: { nombre: { contains: q } } })
     if (estado) and.push({ estado })
 
     // 6) Combino todo


### PR DESCRIPTION
## Summary
- drop `mode: 'insensitive'` from string search filters in request APIs

## Testing
- `npx tsc --noEmit` *(fails: Type '{ nombre: string; } | null' is not assignable to type 'NullableJsonNullValueInput | InputJsonValue | undefined')*
- `npm run build` *(fails to compile)*
- `mysql -h 127.0.0.1 -uroot -padmin -e "SELECT 1"` *(fails: Can't connect to MySQL server)*
- `npx prisma validate`

------
https://chatgpt.com/codex/tasks/task_e_685adaf4750c8327bdd7631d15d9c4ed