### PR TITLE
Add audit column summary

### DIFF
--- a/pages/admin/audit.tsx
+++ b/pages/admin/audit.tsx
@@ -11,9 +11,32 @@ type Log = {
   entity: string
   entityId: number
   timestamp: string
+  changes: any
 }
 
 type Props = { logs: Log[] }
+
+function describeChange(log: Log) {
+  const action = log.action.toUpperCase()
+  const entity = log.entity.toLowerCase()
+  const name =
+    log.changes?.despues?.nombre ||
+    log.changes?.antes?.nombre ||
+    log.changes?.nombre
+  if (action === 'ELIMINAR') {
+    return `Se eliminó ${entity} ${name ?? log.entityId}`
+  }
+  if (action === 'EDITAR') {
+    return `Se modificó ${entity} ${name ?? log.entityId}`
+  }
+  if (action === 'APROBAR') {
+    return `Se aprobó ${entity} ${log.entityId}`
+  }
+  if (action === 'RECHAZAR') {
+    return `Se rechazó ${entity} ${log.entityId}`
+  }
+  return `${action} ${entity} ${log.entityId}`
+}
 
 export default function AuditPage({ logs }: Props) {
   return (
@@ -28,6 +51,7 @@ export default function AuditPage({ logs }: Props) {
               <th>Acción</th>
               <th>Entidad</th>
               <th>Entidad ID</th>
+              <th>Cambio</th>
             </tr>
           </thead>
           <tbody>
@@ -38,6 +62,7 @@ export default function AuditPage({ logs }: Props) {
                 <td>{l.action}</td>
                 <td>{l.entity}</td>
                 <td>{l.entityId}</td>
+                <td>{describeChange(l)}</td>
               </tr>
             ))}
           </tbody>

--- a/pages/api/solicitudes/[id].ts
+++ b/pages/api/solicitudes/[id].ts
@@ -3,6 +3,7 @@ import { prisma } from "../../../lib/prisma";
 import { SolicitudUpdateSchema } from "../../../lib/zodSchemas";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "../auth/[...nextauth]";
+import { getToken } from "next-auth/jwt";
 import { sendStatusEmail } from "../../../lib/mailer";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
@@ -10,14 +11,32 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (!session || (session.user as any).role !== "ADMIN")
     return res.status(403).json({ error: "Solo admin" });
 
+  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+  const actorId = Number(token?.sub);
+
   try {
     const { id } = req.query;
     if (req.method === "PATCH") {
       const upd = SolicitudUpdateSchema.parse(req.body);
+      const before = await prisma.solicitud.findUnique({
+        where: { id: Number(id) },
+        select: { estado: true }
+      });
+
       const sol = await prisma.solicitud.update({
         where: { id: Number(id) },
         data: upd,
         include: { usuario: true, item: true },
+      });
+
+      await prisma.auditLog.create({
+        data: {
+          userId: actorId,
+          action: 'EDITAR',
+          entity: 'Solicitud',
+          entityId: Number(id),
+          changes: { antes: before, despues: upd }
+        }
       });
 
       // enviar correo al solicitante

--- a/pages/mis-solicitudes.tsx
+++ b/pages/mis-solicitudes.tsx
@@ -21,8 +21,10 @@ export default function MisSolicitudes() {
   const [error, setError]         = useState<string|null>(null)
 
   // filtros
-  const [search,  setSearch]  = useState('')
-  const [estado,  setEstado]  = useState('')
+  const [search, setSearch] = useState('')      // filtros aplicados
+  const [estado, setEstado] = useState('')
+  const [searchInput, setSearchInput] = useState('') // valores del formulario
+  const [estadoInput, setEstadoInput] = useState('')
 
   useEffect(() => {
     setLoading(true)
@@ -61,12 +63,12 @@ export default function MisSolicitudes() {
           <input
             type="text"
             placeholder="Buscar equipo…"
-            value={search}
-            onChange={e => setSearch(e.target.value)}
+            value={searchInput}
+            onChange={e => setSearchInput(e.target.value)}
           />
           <select
-            value={estado}
-            onChange={e => setEstado(e.target.value)}
+            value={estadoInput}
+            onChange={e => setEstadoInput(e.target.value)}
           >
             <option value="">Todos los estados</option>
             <option value="PENDIENTE">Pendiente</option>
@@ -74,6 +76,12 @@ export default function MisSolicitudes() {
             <option value="RECHAZADA">Rechazada</option>
             <option value="FINALIZADA">Finalizada</option>
           </select>
+          <button
+            className="btn btn-small btn-primary"
+            onClick={() => { setSearch(searchInput); setEstado(estadoInput); }}
+          >
+            Filtrar
+          </button>
         </div>
 
         {loading ? (


### PR DESCRIPTION
## Summary
- show a "Cambio" column on the audit log page
- derive a short Spanish description from the saved `changes`
- add a filter button on the solicitations page so input doesn't reload after each keystroke

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ad19b06688327be6152de39f12b9c