### PR TITLE
Add filter controls to admin requests

### DIFF
--- a/pages/admin/requests.tsx
+++ b/pages/admin/requests.tsx
@@ -18,19 +18,19 @@ export default function AdminRequestsPage() {
   const [solicitudes, setSolicitudes] = useState<Solicitud[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string|null>(null)
-  const [entidadId, setEntidadId] = useState('')
-  const [fecha, setFecha] = useState('')
-  const [usuario, setUsuario] = useState('')
-  const [item, setItem] = useState('')
+  // filtros por item y estado
+  const [search, setSearch] = useState('')      // filtros aplicados
+  const [estado, setEstado] = useState('')
+  const [searchInput, setSearchInput] = useState('') // valores del formulario
+  const [estadoInput, setEstadoInput] = useState('')
 
   // 1) Carga con filtros
   useEffect(() => {
     setLoading(true)
     const params = new URLSearchParams()
-    if (entidadId) params.set('entidadId', entidadId)
-    if (fecha)     params.set('fecha', fecha)
-    if (usuario)   params.set('usuario', usuario)
-    if (item)      params.set('item', item)
+    if (search) params.set('q', search)
+    if (estado) params.set('estado', estado)
+
     fetch(`/api/admin/requests?${params.toString()}`, { credentials: 'include' })
       .then((res) => {
         if (!res.ok) throw new Error(`Error ${res.status}`)
@@ -39,7 +39,7 @@ export default function AdminRequestsPage() {
       .then((data: Solicitud[]) => setSolicitudes(data))
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false))
-  }, [entidadId, fecha, usuario, item])
+  }, [search, estado])
 
   // 2) Aprobar/Rechazar con comentario
   const handleUpdate = async (
@@ -97,30 +97,30 @@ export default function AdminRequestsPage() {
     <Layout>
       <section className="app-container">
         <h2>Revisión de Solicitudes</h2>
-        <div style={{ display: 'flex', gap: '.5rem', marginBottom: '1rem' }}>
-          <input
-            type="number"
-            placeholder="Entidad ID"
-            value={entidadId}
-            onChange={e => setEntidadId(e.target.value)}
-          />
-          <input
-            type="date"
-            value={fecha}
-            onChange={e => setFecha(e.target.value)}
-          />
+        {/* —————— FILTROS —————— */}
+        <div style={{ display:'flex', gap:'.5rem', marginBottom:'1rem' }}>
           <input
             type="text"
-            placeholder="Usuario"
-            value={usuario}
-            onChange={e => setUsuario(e.target.value)}
+            placeholder="Buscar equipo…"
+            value={searchInput}
+            onChange={e => setSearchInput(e.target.value)}
           />
-          <input
-            type="text"
-            placeholder="Equipo"
-            value={item}
-            onChange={e => setItem(e.target.value)}
-          />
+          <select
+            value={estadoInput}
+            onChange={e => setEstadoInput(e.target.value)}
+          >
+            <option value="">Todos los estados</option>
+            <option value="PENDIENTE">Pendiente</option>
+            <option value="APROBADA">Aprobada</option>
+            <option value="RECHAZADA">Rechazada</option>
+            <option value="FINALIZADA">Finalizada</option>
+          </select>
+          <button
+            className="btn btn-small btn-primary"
+            onClick={() => { setSearch(searchInput); setEstado(estadoInput); }}
+          >
+            Filtrar
+          </button>
         </div>
         <table className="table-minimal">
           <thead>


### PR DESCRIPTION
## Summary
- support filtering admin requests by item name and status

## Testing
- `npm run build` *(fails: Type error in pages/api/admin/departamentos/[id].ts)*

------
https://chatgpt.com/codex/tasks/task_e_685ae45a615c8327863181f85d4d3bdb