### PR TITLE
Improve admin request list

### DIFF
--- a/pages/admin/requests.tsx
+++ b/pages/admin/requests.tsx
@@ -11,6 +11,7 @@ type Solicitud = {
   fechaSolicitud: string
   usuario: { nombre: string }
   item: { nombre: string }
+  comentarios?: string | null
 }
 
 export default function AdminRequestsPage() {
@@ -21,7 +22,6 @@ export default function AdminRequestsPage() {
 
   const [fecha, setFecha] = useState('')
   const [usuario, setUsuario] = useState('')
-  const [item, setItem] = useState('')
   const [search, setSearch] = useState('')
   const [searchInput, setSearchInput] = useState('')
 
@@ -31,7 +31,6 @@ export default function AdminRequestsPage() {
 
     if (fecha) params.set('fecha', fecha)
     if (usuario) params.set('usuario', usuario)
-    if (item) params.set('item', item)
     if (search) params.set('q', search)
 
     fetch(`/api/admin/requests?${params.toString()}`, { credentials: 'include' })
@@ -42,7 +41,7 @@ export default function AdminRequestsPage() {
       .then((data: Solicitud[]) => setSolicitudes(data))
       .catch((err) => setError(err.message))
       .finally(() => setLoading(false))
-  }, [fecha, usuario, item, search])
+  }, [fecha, usuario, search])
 
   const handleUpdate = async (
     id: number,
@@ -97,7 +96,6 @@ export default function AdminRequestsPage() {
         <div style={{ display: 'flex', gap: '.5rem', marginBottom: '1rem' }}>
           <input type="date" value={fecha} onChange={e => setFecha(e.target.value)} />
           <input type="text" placeholder="Usuario" value={usuario} onChange={e => setUsuario(e.target.value)} />
-          <input type="text" placeholder="Equipo" value={item} onChange={e => setItem(e.target.value)} />
         </div>
 
         <div style={{ display: 'flex', gap: '.5rem', marginBottom: '1rem' }}>
@@ -107,38 +105,50 @@ export default function AdminRequestsPage() {
           </button>
         </div>
 
-        <div className="requests-grid">
-          {solicitudes.map((s) => (
-            <div key={s.id} className="request-card">
-              <div className="request-card-header">
-                <span className={`status-badge ${s.estado.toLowerCase()}`}>{s.estado}</span>
-                <span>{new Date(s.fechaSolicitud).toLocaleDateString()}</span>
-              </div>
-              <h4>{s.item.nombre}</h4>
-              <p className="request-user">{s.usuario.nombre}</p>
-              <p>{s.motivo}</p>
-              <div className="actions">
-                {s.estado === 'PENDIENTE' && (
-                  <>
-                    <button className="btn btn-primary btn-small" onClick={() => handleUpdate(s.id, 'APROBADA')}>
-                      <FiCheckCircle size={14} /> Aprobar
-                    </button>{' '}
-                    <button className="btn btn-secondary btn-small" onClick={() => handleUpdate(s.id, 'RECHAZADA')}>
-                      <FiXCircle size={14} /> Rechazar
+        <table className="table-minimal">
+          <thead>
+            <tr>
+              <th>Fecha</th>
+              <th>Usuario</th>
+              <th>Equipo</th>
+              <th>Estado</th>
+              <th>Motivo</th>
+              <th>Comentarios</th>
+              <th>Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {solicitudes.map((s) => (
+              <tr key={s.id}>
+                <td>{new Date(s.fechaSolicitud).toLocaleDateString()}</td>
+                <td>{s.usuario.nombre}</td>
+                <td>{s.item.nombre}</td>
+                <td>{s.estado}</td>
+                <td>{s.motivo}</td>
+                <td>{s.comentarios ?? '—'}</td>
+                <td>
+                  {s.estado === 'PENDIENTE' && (
+                    <>
+                      <button className="btn btn-primary btn-small" onClick={() => handleUpdate(s.id, 'APROBADA')}>
+                        <FiCheckCircle size={14} /> Aprobar
+                      </button>{' '}
+                      <button className="btn btn-secondary btn-small" onClick={() => handleUpdate(s.id, 'RECHAZADA')}>
+                        <FiXCircle size={14} /> Rechazar
+                      </button>
+                    </>
+                  )}
+                  {s.estado === 'APROBADA' && (
+                    <button className="btn btn-primary btn-small" onClick={() => handleDeliver(s.id)}>
+                      Marcar entregado
                     </button>
-                  </>
-                )}
-                {s.estado === 'APROBADA' && (
-                  <button className="btn btn-primary btn-small" onClick={() => handleDeliver(s.id)}>
-                    Marcar entregado
-                  </button>
-                )}
-                {s.estado === 'FINALIZADA' && <span>Finalizada</span>}
-                {s.estado === 'RECHAZADA' && <span>Rechazada</span>}
-              </div>
-            </div>
-          ))}
-        </div>
+                  )}
+                  {s.estado === 'FINALIZADA' && <span>Finalizada</span>}
+                  {s.estado === 'RECHAZADA' && <span>Rechazada</span>}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </section>
     </Layout>
   )

--- a/pages/api/admin/requests/index.ts
+++ b/pages/api/admin/requests/index.ts
@@ -87,6 +87,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       fechaSolicitud: s.fechaSolicitud.toISOString(),
       item:           { nombre: s.item.nombre, departamento: s.item.departamento.nombre },
       usuario:        { nombre: s.usuario.nombre, apellido: s.usuario.apellido, email: s.usuario.email },
+      comentarios:    s.comentarios,
     }))
     return res.status(200).json(solicitudes)
   }


### PR DESCRIPTION
## Summary
- drop redundant item filter box
- add comments to admin requests API
- display admin requests in a table with columns

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685bf55811f48327aae4c22a1bf9b440