### PR TITLE
Implement soft deletion for solicitudes

### DIFF
--- a/pages/api/solicitudes/[id]/delete.ts
+++ b/pages/api/solicitudes/[id]/delete.ts
@@ -22,7 +22,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     select: { usuarioId: true, itemId: true }
   })
 
-  await prisma.solicitud.delete({ where: { id } })
+  await prisma.solicitud.update({
+    where: { id },
+    data: { deleted: true, deletedAt: new Date() }
+  })
 
   await prisma.auditLog.create({
     data: {

--- a/pages/api/solicitudes/index.ts
+++ b/pages/api/solicitudes/index.ts
@@ -31,6 +31,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     const and: any[] = []
     if (q)      and.push({ item: { nombre: { contains: q } } })
     if (estado) and.push({ estado })
+    and.push({ deleted: false })
 
     // 6) Combino todo
     const where = {


### PR DESCRIPTION
## Summary
- update delete API to mark requests as deleted instead of removing them
- filter `/api/solicitudes` to only return non-deleted entries

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685bfbd10040832780b0d6779354f919