### PR TITLE
Implement password reset via email

### DIFF
--- a/lib/mailer.ts
+++ b/lib/mailer.ts
@@ -79,3 +79,27 @@ export async function sendReturnEmail(
     html,
   })
 }
+
+/**
+ * Envía el enlace para restablecer contraseña.
+ */
+export async function sendPasswordResetEmail(to: string, token: string) {
+  const url = `${process.env.NEXTAUTH_URL}/auth/reset-password?token=${encodeURIComponent(
+    token
+  )}`
+
+  const info = await transporter.sendMail({
+    from: process.env.EMAIL_FROM!,
+    to,
+    subject: 'Restablece tu contraseña',
+    html: `
+      <p>Has solicitado cambiar tu contraseña.</p>
+      <p>Haz clic en el siguiente enlace para continuar:</p>
+      <p><a href="${url}">Cambiar contraseña</a></p>
+      <p>Si no fuiste tú, ignora este mensaje.</p>
+    `,
+  })
+
+  const preview = nodemailer.getTestMessageUrl(info)
+  if (preview) console.log('💌 Preview URL:', preview)
+}

--- a/pages/api/auth/reset-password.ts
+++ b/pages/api/auth/reset-password.ts
@@ -1,0 +1,33 @@
+// pages/api/auth/reset-password.ts
+import type { NextApiRequest, NextApiResponse } from 'next'
+import bcrypt from 'bcrypt'
+import { prisma } from '../../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST'])
+    return res.status(405).end()
+  }
+
+  const { token, password, confirmPassword } = req.body
+  if (!token || !password || !confirmPassword) {
+    return res.status(400).json({ message: 'Datos incompletos' })
+  }
+  if (password !== confirmPassword) {
+    return res.status(400).json({ message: 'Las contraseñas no coinciden' })
+  }
+
+  const record = await prisma.passwordResetToken.findUnique({ where: { token } })
+  if (!record || record.expires < new Date()) {
+    return res.status(400).json({ message: 'Token inválido o expirado' })
+  }
+
+  const hash = await bcrypt.hash(password, 10)
+  await prisma.usuario.update({
+    where: { id: record.userId },
+    data: { password: hash },
+  })
+  await prisma.passwordResetToken.delete({ where: { id: record.id } })
+
+  return res.status(200).json({ message: 'Contraseña actualizada' })
+}

--- a/pages/api/auth/reset-request.ts
+++ b/pages/api/auth/reset-request.ts
@@ -1,0 +1,45 @@
+// pages/api/auth/reset-request.ts
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { prisma } from '../../../lib/prisma'
+import { sendPasswordResetEmail } from '../../../lib/mailer'
+import { randomBytes } from 'crypto'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST'])
+    return res.status(405).end()
+  }
+
+  const { email } = req.body
+  if (!email) return res.status(400).json({ message: 'Email requerido' })
+
+  const user = await prisma.usuario.findFirst({
+    where: {
+      OR: [{ email }, { matricula: email }],
+    },
+  })
+
+  if (user) {
+    const token = randomBytes(32).toString('hex')
+    const expires = new Date(Date.now() + 1000 * 60 * 60)
+
+    await prisma.passwordResetToken.deleteMany({ where: { userId: user.id } })
+    await prisma.passwordResetToken.create({
+      data: {
+        token,
+        userId: user.id,
+        expires,
+      },
+    })
+
+    try {
+      await sendPasswordResetEmail(user.email, token)
+    } catch (err) {
+      console.error('Error al enviar correo:', err)
+    }
+  }
+
+  return res.status(200).json({
+    message: 'Si la cuenta existe, recibirás un correo con instrucciones.',
+  })
+}

--- a/pages/auth/forgot-password.tsx
+++ b/pages/auth/forgot-password.tsx
@@ -1,0 +1,65 @@
+// pages/auth/forgot-password.tsx
+import { useState } from 'react'
+import Link from 'next/link'
+
+export default function ForgotPassword() {
+  const [email, setEmail] = useState('')
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setSubmitting(true)
+    const res = await fetch('/api/auth/reset-request', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    })
+    const data = await res.json()
+    setSubmitting(false)
+    if (!res.ok) {
+      setError(data.message)
+    } else {
+      setMessage(data.message)
+    }
+  }
+
+  if (message) {
+    return (
+      <main className="register-page">
+        <h2>Recuperar contraseña</h2>
+        <p className="subheading">{message}</p>
+        <Link href="/auth/signin" className="button primary">
+          Iniciar Sesión
+        </Link>
+      </main>
+    )
+  }
+
+  return (
+    <main className="register-page">
+      <h2>¿Olvidaste tu contraseña?</h2>
+      <p className="subheading">Ingresa tu correo para recibir instrucciones</p>
+      <form className="form-card" onSubmit={handleSubmit}>
+        {error && <p style={{ color: 'red', marginBottom: '1rem' }}>{error}</p>}
+        <div className="form-group">
+          <label>Email o Matrícula</label>
+          <input
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+        <button type="submit" className="button primary large full-width" disabled={submitting}>
+          {submitting ? 'Enviando...' : 'Enviar'}
+        </button>
+        <div className="divider">¿Ya recordaste?</div>
+        <Link href="/auth/signin" className="button secondary large full-width">
+          Iniciar Sesión
+        </Link>
+      </form>
+    </main>
+  )
+}

--- a/pages/auth/reset-password.tsx
+++ b/pages/auth/reset-password.tsx
@@ -1,0 +1,80 @@
+// pages/auth/reset-password.tsx
+import { useState } from 'react'
+import { useRouter } from 'next/router'
+import Link from 'next/link'
+
+export default function ResetPassword() {
+  const router = useRouter()
+  const { token } = router.query
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    if (password !== confirm) {
+      setError('Las contraseñas no coinciden')
+      return
+    }
+    setSubmitting(true)
+    const res = await fetch('/api/auth/reset-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token, password, confirmPassword: confirm }),
+    })
+    const data = await res.json()
+    setSubmitting(false)
+    if (!res.ok) {
+      setError(data.message)
+    } else {
+      setMessage('Contraseña actualizada. Ya puedes iniciar sesión.')
+    }
+  }
+
+  if (message) {
+    return (
+      <main className="register-page">
+        <h2>Cambiar contraseña</h2>
+        <p className="subheading">{message}</p>
+        <Link href="/auth/signin" className="button primary">
+          Iniciar Sesión
+        </Link>
+      </main>
+    )
+  }
+
+  return (
+    <main className="register-page">
+      <h2>Cambiar contraseña</h2>
+      <form className="form-card" onSubmit={handleSubmit}>
+        {error && <p style={{ color: 'red', marginBottom: '1rem' }}>{error}</p>}
+        <div className="form-group">
+          <label>Nueva contraseña</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            minLength={6}
+            required
+          />
+        </div>
+        <div className="form-group">
+          <label>Confirmar contraseña</label>
+          <input
+            type="password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            minLength={6}
+            required
+          />
+        </div>
+        <button type="submit" className="button primary large full-width" disabled={submitting}>
+          {submitting ? 'Actualizando...' : 'Actualizar'}
+        </button>
+      </form>
+    </main>
+  )
+}

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -71,6 +71,9 @@ export default function SignIn({ csrfToken, confirmed }: Props) {
         <button type="submit" className="button primary large full-width">
           Iniciar Sesión
         </button>
+        <Link href="/auth/forgot-password" className="button secondary large full-width">
+          Olvidé mi contraseña
+        </Link>
         <div className="divider">¿No tienes cuenta?</div>
         <Link href="/register" className="button secondary large full-width">
           Registrarse

--- a/prisma/migrations/20250520120000_add_password_reset_token/migration.sql
+++ b/prisma/migrations/20250520120000_add_password_reset_token/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE `PasswordResetToken` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `token` VARCHAR(191) NOT NULL,
+    `userId` INTEGER NOT NULL,
+    `expires` DATETIME(3) NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    UNIQUE INDEX `PasswordResetToken_token_key`(`token`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `PasswordResetToken` ADD CONSTRAINT `PasswordResetToken_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `Usuario`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -110,3 +110,12 @@ model AuditLog {
 
   @@index([entity, entityId])
 }
+
+model PasswordResetToken {
+  id        Int      @id @default(autoincrement())
+  token     String   @unique
+  userId    Int
+  user      Usuario  @relation(fields: [userId], references: [id])
+  expires   DateTime
+  createdAt DateTime @default(now())
+}


### PR DESCRIPTION
## Summary
- add link for password recovery in login page
- create forgot password and reset password pages
- implement API routes for password reset
- send password reset email
- extend Prisma schema and migrations for reset tokens

## Testing
- `npm run build` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685c066a2a2c8327808c5ee0d04f37bb