### PR TITLE
Add cascade delete to password reset relation

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -115,7 +115,7 @@ model PasswordResetToken {
   id        Int      @id @default(autoincrement())
   token     String   @unique
   userId    Int
-  user      Usuario  @relation(fields: [userId], references: [id])
+  user      Usuario  @relation(fields: [userId], references: [id], onDelete: Cascade)
   expires   DateTime
   createdAt DateTime @default(now())
 }


### PR DESCRIPTION
## Summary
- update `PasswordResetToken` relation to cascade deletes
- run Prisma format
- attempt to create migration (fails without database)

## Testing
- `npx prisma format`
- `npx prisma migrate dev --name add_ondelete_cascade` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_685c128455508327800de51ed5523bbc