### PR TITLE
Update README for password reset migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ Este proyecto utiliza Next.js y Prisma. Sigue los pasos a continuacion para conf
    ```bash
    npm install
    ```
-2. Genera el cliente de Prisma:
+2. Aplica la migración `add_password_reset_token` y genera el cliente de Prisma:
    ```bash
+   npx prisma migrate dev
+   # si la migración ya está aplicada puedes solo generar el cliente con:
    npx prisma generate
    ```
-3. Ejecuta las migraciones (si existen) y levanta el servidor de desarrollo:
+3. Levanta el servidor de desarrollo:
    ```bash
-   npx prisma migrate dev # opcional si hay migraciones pendientes
    npm run dev
    ```
 


### PR DESCRIPTION
## Summary
- clarify setup instructions
- mention running `npx prisma migrate dev` (or `prisma generate`) for the `add_password_reset_token` migration

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c1285233c83279f3e7c2b383d6f6a