### PR TITLE
Improved sign-in button styling

### DIFF
--- a/components/Landing.tsx
+++ b/components/Landing.tsx
@@ -1,7 +1,7 @@
 // components/Landing.tsx
 import React from 'react';
 import Link from 'next/link';
-import { FiBox, FiClipboard, FiCheckSquare } from 'react-icons/fi';
+import { FiBox, FiClipboard, FiCheckSquare, FiLogIn } from 'react-icons/fi';
 
 export default function Landing() {
   return (
@@ -23,8 +23,8 @@ export default function Landing() {
           {/* Botones a la derecha */}
           <div>
             {/* <Link> ya genera un <a> internamente, por eso quitamos el <a> extra */}
-            <Link href="/auth/signin" className="button primary" style={{ marginRight: '0.75rem' }}>
-              Iniciar Sesión
+            <Link href="/auth/signin" className="button primary signin-btn" style={{ marginRight: '0.75rem' }}>
+              <FiLogIn /> Iniciar Sesión
             </Link>
             <Link href="/register" className="button secondary">
               Registrarse
@@ -41,8 +41,8 @@ export default function Landing() {
           audiovisuales de la universidad.
         </p>
         <div className="hero-buttons">
-          <Link href="/auth/signin" className="button primary large">
-            Iniciar Sesión
+          <Link href="/auth/signin" className="button primary large signin-btn">
+            <FiLogIn /> Iniciar Sesión
           </Link>
           <Link href="/register" className="button secondary large">
             Registrarse

--- a/pages/auth/forgot-password.tsx
+++ b/pages/auth/forgot-password.tsx
@@ -1,6 +1,7 @@
 // pages/auth/forgot-password.tsx
 import { useState } from 'react'
 import Link from 'next/link'
+import { FiLogIn } from 'react-icons/fi'
 
 export default function ForgotPassword() {
   const [email, setEmail] = useState('')
@@ -31,8 +32,8 @@ export default function ForgotPassword() {
       <main className="register-page">
         <h2>Recuperar contraseña</h2>
         <p className="subheading">{message}</p>
-        <Link href="/auth/signin" className="button primary">
-          Iniciar Sesión
+        <Link href="/auth/signin" className="button primary signin-btn">
+          <FiLogIn /> Iniciar Sesión
         </Link>
       </main>
     )
@@ -56,8 +57,8 @@ export default function ForgotPassword() {
           {submitting ? 'Enviando...' : 'Enviar'}
         </button>
         <div className="divider">¿Ya recordaste?</div>
-        <Link href="/auth/signin" className="button secondary large full-width">
-          Iniciar Sesión
+        <Link href="/auth/signin" className="button secondary large full-width signin-btn">
+          <FiLogIn /> Iniciar Sesión
         </Link>
       </form>
     </main>

--- a/pages/auth/reset-password.tsx
+++ b/pages/auth/reset-password.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
+import { FiLogIn } from 'react-icons/fi'
 
 export default function ResetPassword() {
   const router = useRouter()
@@ -54,8 +55,8 @@ export default function ResetPassword() {
       <main className="register-page">
         <h2>Cambiar contraseña</h2>
         <p className="subheading">{message}</p>
-        <Link href="/auth/signin" className="button primary">
-          Iniciar Sesión
+        <Link href="/auth/signin" className="button primary signin-btn">
+          <FiLogIn /> Iniciar Sesión
         </Link>
       </main>
     )

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -1,5 +1,6 @@
 // pages/auth/signin.tsx
 import { useState, FormEvent } from 'react'
+import { FiLogIn } from 'react-icons/fi'
 import { getCsrfToken, signIn, getSession } from 'next-auth/react'
 import { GetServerSideProps } from 'next'
 import { useRouter } from 'next/router'
@@ -68,8 +69,8 @@ export default function SignIn({ csrfToken, confirmed }: Props) {
             required
           />
         </div>
-        <button type="submit" className="button primary large full-width">
-          Iniciar Sesión
+        <button type="submit" className="button primary large full-width signin-btn">
+          <FiLogIn /> Iniciar Sesión
         </button>
         <Link href="/auth/forgot-password" className="button secondary large full-width">
           Olvidé mi contraseña

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -1,6 +1,7 @@
 // pages/register.tsx
 import { useState } from 'react';
 import Link from 'next/link';
+import { FiLogIn } from 'react-icons/fi';
 
 export default function Register() {
   const [form, setForm] = useState({
@@ -56,8 +57,8 @@ export default function Register() {
       <main className="register-page">
         <h2>¡Registro exitoso!</h2>
         <p className="subheading">{submittedMessage}</p>
-        <Link href="/auth/signin" className="button primary">
-          Ir a Iniciar Sesión
+        <Link href="/auth/signin" className="button primary signin-btn">
+          <FiLogIn /> Ir a Iniciar Sesión
         </Link>
       </main>
     );
@@ -149,8 +150,8 @@ export default function Register() {
         </button>
 
         <div className="divider">¿Ya tienes cuenta?</div>
-        <Link href="/auth/signin" className="button secondary large full-width">
-          Iniciar Sesión
+        <Link href="/auth/signin" className="button secondary large full-width signin-btn">
+          <FiLogIn /> Iniciar Sesión
         </Link>
       </form>
     </main>

--- a/styles/global.css
+++ b/styles/global.css
@@ -179,6 +179,29 @@ nav {
   transform: translateY(-3px) scale(1.02);
 }
 
+/* Estilo especial para botones de inicio de sesión */
+.button.signin-btn {
+  position: relative;
+  overflow: hidden;
+}
+.button.signin-btn svg {
+  margin-right: 0.5rem;
+}
+.button.signin-btn::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: rgba(255, 255, 255, 0.2);
+  transform: skewX(-20deg);
+  transition: left 0.5s;
+}
+.button.signin-btn:hover::after {
+  left: 200%;
+}
+
 /* ==========================================================================
    7) HERO
    ========================================================================== */


### PR DESCRIPTION
## Summary
- animate sign-in buttons with modern hover effect
- include login icons on all sign-in links

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685c194a71748327ac774ab9ae9330a5