### PR TITLE
Implement email verification tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,13 +2,13 @@ DATABASE_URL="mysql://root:admin@localhost:3306/unphu"
 NEXTAUTH_SECRET="3080BB51BA34B8534FB33F060AC9AB8E2155"
 
 # Credenciales SMTP (puede ser Mailtrap, SendGrid, etc.)
-SMTP_HOST=smtp.elasticemail.com
-SMTP_PORT=2525
-SMTP_USER=ys21-0834@unphu.edu.do
-SMTP_PASS=3080BB51BA34B8534FB33F060AC9AB8E2155
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your_smtp_user
+SMTP_PASS=your_smtp_pass
 
 # Dirección "From" — la que verá el destinatario
-EMAIL_FROM="ys21-0834@unphu.edu.do"
+EMAIL_FROM="no-reply@example.com"
 
 # URL base de tu app (para enlaces en email)
 NEXTAUTH_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Este proyecto utiliza Next.js y Prisma. Sigue los pasos a continuacion para conf
    ```bash
    npm install
    ```
-2. Aplica la migración `add_password_reset_token` y genera el cliente de Prisma:
+2. Aplica la migración para los tokens de verificación de email y genera el cliente de Prisma:
    ```bash
    npx prisma migrate dev
    # si la migración ya está aplicada puedes solo generar el cliente con:
@@ -22,3 +22,9 @@ Este proyecto utiliza Next.js y Prisma. Sigue los pasos a continuacion para conf
 ## Variables de entorno
 
 Copia `.env.example` a `.env` y ajusta los valores antes de iniciar la aplicacion.
+
+## Confirmación de cuenta
+
+Al registrarse, se genera un token de verificación único que se almacena en la tabla `EmailVerificationToken` y expira a las 24 horas. El correo de bienvenida incluye un enlace con este token. El usuario debe abrirlo para activar su cuenta.
+
+Si el token es válido se marca la columna `confirmed` en `Usuario` y el registro del token se elimina.

--- a/lib/mailer.ts
+++ b/lib/mailer.ts
@@ -16,10 +16,10 @@ export const transporter = nodemailer.createTransport({
 export async function sendConfirmationEmail(
   email: string,
   nombre: string,
-  matricula: string
+  token: string
 ) {
   const confirmUrl = `${process.env.NEXTAUTH_URL}/api/confirm?token=${encodeURIComponent(
-    matricula
+    token
   )}`
 
   const info = await transporter.sendMail({

--- a/pages/api/confirm.ts
+++ b/pages/api/confirm.ts
@@ -6,19 +6,26 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
 ) {
-  // El correo de confirmación envía la matrícula como "token"
   const { token } = req.query
   if (typeof token !== 'string') {
-    return res.status(400).send('Matrícula inválida')
+    return res.status(400).send('Token inválido')
   }
   try {
+    const record = await prisma.emailVerificationToken.findUnique({
+      where: { token },
+    })
+    if (!record || record.expires < new Date()) {
+      return res.status(400).send('Token inválido o expirado')
+    }
+
     await prisma.usuario.update({
-      where: { matricula: token },
+      where: { id: record.userId },
       data: { confirmed: true },
-    });
-    return res.redirect('/auth/signin?confirmed=1');
+    })
+    await prisma.emailVerificationToken.delete({ where: { id: record.id } })
+    return res.redirect('/auth/signin?confirmed=1')
   } catch (err) {
-    console.error('Error confirmando usuario:', err);
-    return res.status(500).send('No fue posible confirmar tu cuenta');
+    console.error('Error confirmando usuario:', err)
+    return res.status(500).send('No fue posible confirmar tu cuenta')
   }
 }

--- a/pages/api/register.ts
+++ b/pages/api/register.ts
@@ -3,6 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 import bcrypt from 'bcrypt';
 import { prisma } from '../../lib/prisma';
 import { sendConfirmationEmail } from '../../lib/mailer';
+import { randomBytes } from 'crypto';
 
 type Data = { message: string };
 
@@ -41,10 +42,21 @@ export default async function handler(
       },
     });
 
+    const token = randomBytes(32).toString('hex');
+    const expires = new Date(Date.now() + 1000 * 60 * 60 * 24);
+    await prisma.emailVerificationToken.create({
+      data: {
+        token,
+        userId: user.id,
+        expires,
+      },
+    });
+
     // Envío obligatorio de correo; si falla hacemos rollback
     try {
-      await sendConfirmationEmail(user.email, user.nombre, user.matricula);
+      await sendConfirmationEmail(user.email, user.nombre, token);
     } catch (mailErr) {
+      await prisma.emailVerificationToken.deleteMany({ where: { userId: user.id } });
       await prisma.usuario.delete({ where: { id: user.id } });
       console.error('Error al enviar correo:', mailErr);
       return res.status(500).json({

--- a/prisma/migrations/20250625190310_add_email_verification_token/migration.sql
+++ b/prisma/migrations/20250625190310_add_email_verification_token/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE `EmailVerificationToken` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `token` VARCHAR(191) NOT NULL,
+    `userId` INTEGER NOT NULL,
+    `expires` DATETIME(3) NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+
+    UNIQUE INDEX `EmailVerificationToken_token_key`(`token`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `EmailVerificationToken` ADD CONSTRAINT `EmailVerificationToken_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `Usuario`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,17 +14,18 @@ generator erd {
 }
 
 model Usuario {
-  id                  Int                  @id @default(autoincrement())
-  matricula           String               @unique
-  email               String               @unique
-  nombre              String
-  apellido            String
-  password            String
-  confirmed           Boolean              @default(false)
-  rol                 Rol                  @default(USER)
-  solicitudes         Solicitud[]
-  auditLogs           AuditLog[] // Relación inversa para logs de este usuario
-  passwordResetTokens PasswordResetToken[]
+  id                      Int                      @id @default(autoincrement())
+  matricula               String                   @unique
+  email                   String                   @unique
+  nombre                  String
+  apellido                String
+  password                String
+  confirmed               Boolean                  @default(false)
+  rol                     Rol                      @default(USER)
+  solicitudes             Solicitud[]
+  auditLogs               AuditLog[] // Relación inversa para logs de este usuario
+  passwordResetTokens     PasswordResetToken[]
+  emailVerificationTokens EmailVerificationToken[]
 
   // Campos para asignar departamento
   departamentoId Int? // ← añadido
@@ -112,6 +113,15 @@ model AuditLog {
 }
 
 model PasswordResetToken {
+  id        Int      @id @default(autoincrement())
+  token     String   @unique
+  userId    Int
+  user      Usuario  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  expires   DateTime
+  createdAt DateTime @default(now())
+}
+
+model EmailVerificationToken {
   id        Int      @id @default(autoincrement())
   token     String   @unique
   userId    Int


### PR DESCRIPTION
## Summary
- add `EmailVerificationToken` prisma model
- generate migration and regenerate prisma client
- create verification tokens at registration and send by email
- validate token in `/api/confirm`
- update mailer and `.env.example`
- document email confirmation flow in README

## Testing
- `npx prisma migrate dev --name add_email_verification_token` *(fails: Can't reach database server)*
- `npx prisma generate`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685c472662608327a0e26527b4d83d9d