### PR TITLE
Integrate Google OAuth support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ EMAIL_FROM="no-reply@example.com"
 # URL base de tu app (para enlaces en email)
 NEXTAUTH_URL=http://localhost:3000
 
+# OAuth de Google
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+

--- a/README.md
+++ b/README.md
@@ -12,16 +12,24 @@ Este proyecto utiliza Next.js y Prisma. Sigue los pasos a continuacion para conf
    ```bash
    npx prisma migrate dev
    # si la migración ya está aplicada puedes solo generar el cliente con:
-   npx prisma generate
+  npx prisma generate
    ```
 3. Levanta el servidor de desarrollo:
    ```bash
-   npm run dev
-   ```
+ npm run dev
+  ```
 
 ## Variables de entorno
 
 Copia `.env.example` a `.env` y ajusta los valores antes de iniciar la aplicacion.
+
+## Configurar OAuth de Google
+
+1. Crea un proyecto en [Google Cloud Console](https://console.cloud.google.com/).
+2. Habilita el inicio de sesión y crea credenciales OAuth 2.0.
+3. Usa `http://localhost:3000/api/auth/callback/google` como URI de redirección autorizada.
+4. Guarda el Client ID y Client Secret en `.env` como `GOOGLE_CLIENT_ID` y `GOOGLE_CLIENT_SECRET`.
+5. Ejecuta `npx prisma migrate dev` para crear la tabla `Account`.
 
 ## Confirmación de cuenta
 

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,6 +1,7 @@
 // pages/api/auth/[...nextauth].ts
 import NextAuth, { type NextAuthOptions } from 'next-auth'
 import CredentialsProvider from 'next-auth/providers/credentials'
+import GoogleProvider from 'next-auth/providers/google'
 import { PrismaAdapter } from '@next-auth/prisma-adapter'
 import bcrypt from 'bcrypt'
 import { prisma } from '../../../lib/prisma'
@@ -41,8 +42,18 @@ export const authOptions: NextAuthOptions = {
         }
       },
     }),
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    }),
   ],
   callbacks: {
+    async signIn({ user, account }) {
+      if (account?.provider === 'google') {
+        if (!user.email?.endsWith('@unphu.edu.do')) return false
+      }
+      return true
+    },
     // Guardamos el rol en el token
     async jwt({ token, user }) {
       if (user) {

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -72,6 +72,13 @@ export default function SignIn({ csrfToken, confirmed }: Props) {
         <button type="submit" className="button primary large full-width signin-btn">
           <FiLogIn /> Iniciar Sesión
         </button>
+        <button
+          type="button"
+          className="button secondary large full-width"
+          onClick={() => signIn('google')}
+        >
+          Iniciar con Google
+        </button>
         <Link href="/auth/forgot-password" className="button secondary large full-width">
           Olvidé mi contraseña
         </Link>

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -1,6 +1,7 @@
 // pages/register.tsx
 import { useState } from 'react';
 import Link from 'next/link';
+import { signIn } from 'next-auth/react';
 import { FiLogIn } from 'react-icons/fi';
 
 export default function Register() {
@@ -147,6 +148,13 @@ export default function Register() {
           disabled={submitting}
         >
           {submitting ? 'Registrando...' : 'Registrarse'}
+        </button>
+        <button
+          type="button"
+          className="button secondary large full-width"
+          onClick={() => signIn('google')}
+        >
+          Registrarse con Google
         </button>
 
         <div className="divider">¿Ya tienes cuenta?</div>

--- a/prisma/migrations/20250704121517_add_account_model/migration.sql
+++ b/prisma/migrations/20250704121517_add_account_model/migration.sql
@@ -1,0 +1,21 @@
+-- CreateTable
+CREATE TABLE `Account` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `userId` INTEGER NOT NULL,
+    `type` VARCHAR(191) NOT NULL,
+    `provider` VARCHAR(191) NOT NULL,
+    `providerAccountId` VARCHAR(191) NOT NULL,
+    `refresh_token` TEXT NULL,
+    `access_token` TEXT NULL,
+    `expires_at` INTEGER NULL,
+    `token_type` VARCHAR(191) NULL,
+    `scope` VARCHAR(191) NULL,
+    `id_token` TEXT NULL,
+    `session_state` VARCHAR(191) NULL,
+
+    UNIQUE INDEX `Account_provider_providerAccountId_key`(`provider`, `providerAccountId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `Account` ADD CONSTRAINT `Account_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `Usuario`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,7 @@ model Usuario {
   auditLogs               AuditLog[] // Relación inversa para logs de este usuario
   passwordResetTokens     PasswordResetToken[]
   emailVerificationTokens EmailVerificationToken[]
+  accounts                Account[]
 
   // Campos para asignar departamento
   departamentoId Int? // ← añadido
@@ -128,4 +129,22 @@ model EmailVerificationToken {
   user      Usuario  @relation(fields: [userId], references: [id], onDelete: Cascade)
   expires   DateTime
   createdAt DateTime @default(now())
+}
+
+model Account {
+  id                 Int      @id @default(autoincrement())
+  userId             Int
+  type               String
+  provider           String
+  providerAccountId  String
+  refresh_token      String?  @db.Text
+  access_token       String?  @db.Text
+  expires_at         Int?
+  token_type         String?
+  scope              String?
+  id_token           String?  @db.Text
+  session_state      String?
+  user               Usuario  @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
 }


### PR DESCRIPTION
## Summary
- add Google provider in NextAuth configuration
- restrict sign in to @unphu.edu.do emails
- introduce Account model and migration
- show Google sign-in buttons on signin and register pages
- document Google OAuth setup and env vars

## Testing
- `npm run build`
- `npx prisma migrate dev --name add-account-model` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_6867c44b71e4832792dae1433cda4d18