### PR TITLE
Rename Usuario to User

### DIFF
--- a/pages/admin/departments.tsx
+++ b/pages/admin/departments.tsx
@@ -256,7 +256,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async ctx => {
     orderBy: { nombre: 'asc' },
   })
 
-  const usuarios = await prisma.usuario.findMany({
+  const usuarios = await prisma.user.findMany({
     select: { id: true, nombre: true, apellido: true },
     orderBy: { nombre: 'asc' },
   })

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -75,7 +75,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   const { prisma } = await import('../../lib/prisma')
 
   // 3) Obtenemos el nombre para el saludo
-  const user = await prisma.usuario.findUnique({
+  const user = await prisma.user.findUnique({
     where: { email: session.user.email! },
   })
   if (!user) {

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -296,7 +296,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async ctx => {
     return { redirect: { destination: '/', permanent: false } }
   }
   const { prisma } = await import('../../lib/prisma')
-  const users = await prisma.usuario.findMany({
+  const users = await prisma.user.findMany({
     select: {
       id: true,
       matricula: true,

--- a/pages/api/admin/users/[id].ts
+++ b/pages/api/admin/users/[id].ts
@@ -27,7 +27,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return res.status(400).json({ message: 'Faltan campos obligatorios' })
     }
     try {
-      const before = await prisma.usuario.findUnique({
+      const before = await prisma.user.findUnique({
         where: { id: userId },
         select: { nombre: true, apellido: true, email: true, rol: true }
       })
@@ -36,7 +36,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       if (password) {
         data.password = await bcrypt.hash(password, 10)
       }
-      const updated = await prisma.usuario.update({
+      const updated = await prisma.user.update({
         where: { id: userId },
         data,
         select: {
@@ -68,7 +68,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   // 3) DELETE /api/admin/users/:id → eliminar usuario
   if (req.method === 'DELETE') {
     try {
-      const before = await prisma.usuario.findUnique({
+      const before = await prisma.user.findUnique({
         where: { id: userId },
         select: { nombre: true, apellido: true, email: true }
       })
@@ -76,7 +76,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       await prisma.$transaction([
         prisma.solicitud.deleteMany({ where: { usuarioId: userId } }),
         prisma.auditLog.deleteMany({ where: { userId } }),
-        prisma.usuario.delete({ where: { id: userId } }),
+        prisma.user.delete({ where: { id: userId } }),
       ])
 
       await prisma.auditLog.create({

--- a/pages/api/admin/users/index.ts
+++ b/pages/api/admin/users/index.ts
@@ -14,7 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   // 2) GET /api/admin/users → lista usuarios
   if (req.method === 'GET') {
-    const users = await prisma.usuario.findMany({
+    const users = await prisma.user.findMany({
       select: {
         id: true,
         matricula: true,
@@ -36,7 +36,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
     try {
       const hash = await bcrypt.hash(password, 10)
-      const created = await prisma.usuario.create({
+      const created = await prisma.user.create({
         data: { matricula, nombre, apellido, email, rol, password: hash, confirmed: true },
         select: {
           id: true,

--- a/pages/api/admin/users[id].ts
+++ b/pages/api/admin/users[id].ts
@@ -33,7 +33,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         data.password = hash
       }
 
-      await prisma.usuario.update({
+      await prisma.user.update({
         where: { id },
         data,
       })

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -20,7 +20,7 @@ export const authOptions: NextAuthOptions = {
       async authorize(creds) {
         if (!creds?.matricula || !creds.password) return null
 
-        const user = await prisma.usuario.findFirst({
+        const user = await prisma.user.findFirst({
           where: {
             OR: [
               { matricula: creds.matricula },

--- a/pages/api/auth/reset-password.ts
+++ b/pages/api/auth/reset-password.ts
@@ -23,7 +23,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const hash = await bcrypt.hash(password, 10)
-  await prisma.usuario.update({
+  await prisma.user.update({
     where: { id: record.userId },
     data: { password: hash },
   })

--- a/pages/api/auth/reset-request.ts
+++ b/pages/api/auth/reset-request.ts
@@ -13,7 +13,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const { email } = req.body
   if (!email) return res.status(400).json({ message: 'Email requerido' })
 
-  const user = await prisma.usuario.findFirst({
+  const user = await prisma.user.findFirst({
     where: {
       OR: [{ email }, { matricula: email }],
     },

--- a/pages/api/confirm.ts
+++ b/pages/api/confirm.ts
@@ -18,7 +18,7 @@ export default async function handler(
       return res.status(400).send('Token inválido o expirado')
     }
 
-    await prisma.usuario.update({
+    await prisma.user.update({
       where: { id: record.userId },
       data: { confirmed: true },
     })

--- a/pages/api/register.ts
+++ b/pages/api/register.ts
@@ -25,13 +25,13 @@ export default async function handler(
   }
 
   try {
-    const exists = await prisma.usuario.findUnique({ where: { matricula } });
+    const exists = await prisma.user.findUnique({ where: { matricula } });
     if (exists) {
       return res.status(400).json({ message: 'Matrícula ya registrada' });
     }
 
     const hashed = await bcrypt.hash(password, 10);
-    const user = await prisma.usuario.create({
+    const user = await prisma.user.create({
       data: {
         matricula,
         email: `${matricula}@unphu.edu.do`,
@@ -57,7 +57,7 @@ export default async function handler(
       await sendConfirmationEmail(user.email, user.nombre, token);
     } catch (mailErr) {
       await prisma.emailVerificationToken.deleteMany({ where: { userId: user.id } });
-      await prisma.usuario.delete({ where: { id: user.id } });
+      await prisma.user.delete({ where: { id: user.id } });
       console.error('Error al enviar correo:', mailErr);
       return res.status(500).json({
         message:

--- a/pages/api/solicitudes/index.ts
+++ b/pages/api/solicitudes/index.ts
@@ -10,7 +10,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const userId = Number(token.sub)
 
   // 2) Recupero departamento del usuario
-  const usr = await prisma.usuario.findUnique({
+  const usr = await prisma.user.findUnique({
     where: { id: userId },
     select: { departamentoId: true }
   })

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -75,7 +75,7 @@ export default function SignIn({ csrfToken, confirmed }: Props) {
         <button
           type="button"
           className="button secondary large full-width"
-          onClick={() => signIn('google')}
+          onClick={() => signIn('google', { prompt: 'select_account' })}
         >
           Iniciar con Google
         </button>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -103,7 +103,7 @@ export const getServerSideProps: GetServerSideProps<Props> = async (ctx) => {
   }
 
   // Buscamos el usuario
-  const user = await prisma.usuario.findUnique({
+  const user = await prisma.user.findUnique({
     where: { email: session.user.email },
   })
   if (!user) {

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -152,7 +152,7 @@ export default function Register() {
         <button
           type="button"
           className="button secondary large full-width"
-          onClick={() => signIn('google')}
+          onClick={() => signIn('google', { prompt: 'select_account' })}
         >
           Registrarse con Google
         </button>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,8 +9,10 @@ generator client {
 
 generator erd {
   provider = "prisma-erd-generator"
-  output   = "./ERD"
+  output   = "./ERD.svg"
   format   = "svg" // puedes usar svg o png
+  mmdcPath = "./node_modules/prisma-erd-generator/node_modules/.bin"
+  puppeteerConfig = "./puppeteerConfig.json"
 }
 
 model User {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,7 +13,8 @@ generator erd {
   format   = "svg" // puedes usar svg o png
 }
 
-model Usuario {
+model User {
+  @@map("Usuario")
   id                      Int                      @id @default(autoincrement())
   matricula               String                   @unique
   email                   String                   @unique
@@ -48,7 +49,7 @@ model Departamento {
   items       Item[]
 
   // Relación inversa para usuarios asignados
-  usuarios Usuario[] // ← añadido
+  usuarios User[] // ← añadido
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -85,7 +86,7 @@ model Solicitud {
   motivo         String
   estado         EstadoSolicitud @default(PENDIENTE)
   comentarios    String?
-  usuario        Usuario         @relation(fields: [usuarioId], references: [id])
+  usuario        User            @relation(fields: [usuarioId], references: [id])
   item           Item            @relation(fields: [itemId], references: [id])
   createdAt      DateTime        @default(now())
   updatedAt      DateTime        @updatedAt
@@ -108,7 +109,7 @@ model AuditLog {
   entityId  Int
   timestamp DateTime @default(now())
   changes   Json?
-  user      Usuario  @relation(fields: [userId], references: [id])
+  user      User     @relation(fields: [userId], references: [id])
 
   @@index([entity, entityId])
 }
@@ -117,7 +118,7 @@ model PasswordResetToken {
   id        Int      @id @default(autoincrement())
   token     String   @unique
   userId    Int
-  user      Usuario  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   expires   DateTime
   createdAt DateTime @default(now())
 }
@@ -126,7 +127,7 @@ model EmailVerificationToken {
   id        Int      @id @default(autoincrement())
   token     String   @unique
   userId    Int
-  user      Usuario  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   expires   DateTime
   createdAt DateTime @default(now())
 }
@@ -144,7 +145,7 @@ model Account {
   scope              String?
   id_token           String?  @db.Text
   session_state      String?
-  user               Usuario  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user               User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@unique([provider, providerAccountId])
 }

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -6,7 +6,7 @@ async function main() {
 
   const hash = await bcrypt.hash('Admin@123', 10)
 
-  await prisma.usuario.upsert({
+  await prisma.user.upsert({
     where: { matricula: 'admin' },
     update: {},
     create: {

--- a/puppeteerConfig.json
+++ b/puppeteerConfig.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+}


### PR DESCRIPTION
## Summary
- rename `Usuario` model to `User`
- update Prisma relations and generated client usage
- adjust seed and API routes
- run Prisma generate (fails ERD generation)
- attempt migration but DB not reachable
- pass `prompt: 'select_account'` when invoking Google login to allow switching accounts

## Testing
- `npx prisma generate`
- `npx prisma migrate dev -n rename-user-model` *(fails: Can't reach database)*
- `npm run build`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_6867cef3c154832790457872841e3674