### PR TITLE
Fix NextAuth user creation with custom schema

### DIFF
--- a/lib/customPrismaAdapter.ts
+++ b/lib/customPrismaAdapter.ts
@@ -1,0 +1,43 @@
+import { PrismaClient } from '@prisma/client'
+import { PrismaAdapter } from '@next-auth/prisma-adapter'
+import type { Adapter, AdapterUser } from 'next-auth/adapters'
+import bcrypt from 'bcrypt'
+import { randomBytes } from 'crypto'
+
+/**
+ * Prisma adapter extendido para poblar campos personalizados
+ * cuando se crea un usuario via OAuth (ej. Google).
+ */
+export function CustomPrismaAdapter(prisma: PrismaClient): Adapter {
+  const baseAdapter = PrismaAdapter(prisma)
+
+  return {
+    ...baseAdapter,
+    async createUser(data: any) {
+      const [nombre, ...rest] = data.name?.split(' ') ?? ['']
+      const apellido = rest.join(' ')
+      const matricula = data.email
+        ? data.email.split('@')[0]
+        : randomBytes(6).toString('hex')
+      const password = await bcrypt.hash(randomBytes(16).toString('hex'), 10)
+
+      const user = await prisma.user.create({
+        data: {
+          matricula,
+          nombre,
+          apellido,
+          email: data.email!,
+          password,
+          confirmed: true,
+        },
+      })
+
+      return {
+        id: user.id.toString(),
+        name: data.name ?? null,
+        email: user.email,
+        emailVerified: null,
+      } as AdapterUser
+    },
+  }
+}

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -2,12 +2,12 @@
 import NextAuth, { type NextAuthOptions } from 'next-auth'
 import CredentialsProvider from 'next-auth/providers/credentials'
 import GoogleProvider from 'next-auth/providers/google'
-import { PrismaAdapter } from '@next-auth/prisma-adapter'
+import { CustomPrismaAdapter } from '../../../lib/customPrismaAdapter'
 import bcrypt from 'bcrypt'
 import { prisma } from '../../../lib/prisma'
 
 export const authOptions: NextAuthOptions = {
-  adapter: PrismaAdapter(prisma),
+  adapter: CustomPrismaAdapter(prisma),
   pages: { signIn: '/auth/signin' },
   session: { strategy: 'jwt' },
   providers: [


### PR DESCRIPTION
## Summary
- add custom Prisma adapter to populate required user fields when signing in with Google
- use the custom adapter in NextAuth configuration

## Testing
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867e5915e5c83279d971eb05b117f33