### PR TITLE
Fix adapter user ID type

### DIFF
--- a/lib/customPrismaAdapter.ts
+++ b/lib/customPrismaAdapter.ts
@@ -33,11 +33,15 @@ export function CustomPrismaAdapter(prisma: PrismaClient): Adapter {
       })
 
       return {
-        id: user.id.toString(),
+        // Return the numeric id directly instead of casting to a string.
+        // The object is later cast to `AdapterUser`, which expects `id` to be
+        // a string, but keeping it as a number avoids issues when other
+        // adapter methods (e.g. linkAccount) expect an integer.
+        id: user.id,
         name: data.name ?? null,
         email: user.email,
         emailVerified: null,
-      } as AdapterUser
+      } as unknown as AdapterUser
     },
   }
 }


### PR DESCRIPTION
## Summary
- return a numeric `user.id` from the custom Prisma adapter

## Testing
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867ee3bcc0483279a824b42bb4abf52