### PR TITLE
Fix credentials provider id type

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -35,11 +35,13 @@ export const authOptions: NextAuthOptions = {
 
         // 👉 Devuelve el campo "rol" (no "role")
         return {
-          id: user.id.toString(),
+          // Keep the numeric id so other adapter methods receive a number
+          // instead of a string.
+          id: user.id,
           name: `${user.nombre} ${user.apellido}`,
           email: user.email,
           rol: user.rol,
-        }
+        } as any
       },
     }),
     GoogleProvider({


### PR DESCRIPTION
## Summary
- use numeric ID in the credentials provider to align with the custom Prisma adapter

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6867fb2b3868832788148951d719fc2b