### PR TITLE
Add Google OAuth scopes support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,4 +16,5 @@ NEXTAUTH_URL=http://localhost:3000
 # OAuth de Google
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
+GOOGLE_OAUTH_SCOPES=openid profile email
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Copia `.env.example` a `.env` y ajusta los valores antes de iniciar la aplicacio
 2. Habilita el inicio de sesión y crea credenciales OAuth 2.0.
 3. Usa `http://localhost:3000/api/auth/callback/google` como URI de redirección autorizada.
 4. Guarda el Client ID y Client Secret en `.env` como `GOOGLE_CLIENT_ID` y `GOOGLE_CLIENT_SECRET`.
-5. Ejecuta `npx prisma migrate dev` para crear la tabla `Account`.
+5. Define los alcances en `GOOGLE_OAUTH_SCOPES` (consulta los [scopes disponibles](https://developers.google.com/identity/protocols/oauth2/scopes)).
+6. Ejecuta `npx prisma migrate dev` para crear la tabla `Account`.
 
 ## Confirmación de cuenta
 

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -47,6 +47,7 @@ export const authOptions: NextAuthOptions = {
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID!,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+      authorization: { params: { scope: process.env.GOOGLE_OAUTH_SCOPES } },
     }),
   ],
   callbacks: {


### PR DESCRIPTION
## Summary
- support custom Google OAuth scopes in NextAuth config
- document `GOOGLE_OAUTH_SCOPES` and provide example
- add env variable placeholder in `.env.example`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868088638c48327a37db3a9ea4eb5cc