### PR TITLE
Allow Gmail sign-in

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -53,7 +53,10 @@ export const authOptions: NextAuthOptions = {
   callbacks: {
     async signIn({ user, account }) {
       if (account?.provider === 'google') {
-        if (!user.email?.endsWith('@unphu.edu.do')) return false
+        const allowed = ['@unphu.edu.do', '@gmail.com']
+        if (!allowed.some(domain => user.email?.endsWith(domain))) {
+          return false
+        }
       }
       return true
     },


### PR DESCRIPTION
## Summary
- permit Google OAuth sign-ins for `@gmail.com` addresses

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68680b798ed08327b529cb46c84b6e56