### PR TITLE
Add warning when GOOGLE_OAUTH_SCOPES env missing

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -6,6 +6,14 @@ import { CustomPrismaAdapter } from '../../../lib/customPrismaAdapter'
 import bcrypt from 'bcrypt'
 import { prisma } from '../../../lib/prisma'
 
+// Ensure Google OAuth scopes are defined before initializing NextAuth.
+if (!process.env.GOOGLE_OAUTH_SCOPES || process.env.GOOGLE_OAUTH_SCOPES.trim() === '') {
+  console.warn(
+    'GOOGLE_OAUTH_SCOPES is not set or empty. Using default "openid profile email". Check your .env file.'
+  )
+  process.env.GOOGLE_OAUTH_SCOPES = 'openid profile email'
+}
+
 export const authOptions: NextAuthOptions = {
   adapter: CustomPrismaAdapter(prisma),
   pages: { signIn: '/auth/signin' },


### PR DESCRIPTION
## Summary
- warn when `GOOGLE_OAUTH_SCOPES` isn't defined and set default scope

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68681181dfc88327a9eb1e89654a6345