### PR TITLE
Restrict Google login domain

### DIFF
--- a/lib/customPrismaAdapter.ts
+++ b/lib/customPrismaAdapter.ts
@@ -14,6 +14,11 @@ export function CustomPrismaAdapter(prisma: PrismaClient): Adapter {
   return {
     ...baseAdapter,
     async createUser(data: any) {
+      const allowedDomain = '@unphu.edu.do'
+      if (!data.email?.endsWith(allowedDomain)) {
+        throw new Error('Solo se permiten correos ' + allowedDomain)
+      }
+
       const [nombre, ...rest] = data.name?.split(' ') ?? ['']
       const apellido = rest.join(' ')
       const matricula = data.email

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -61,8 +61,8 @@ export const authOptions: NextAuthOptions = {
   callbacks: {
     async signIn({ user, account }) {
       if (account?.provider === 'google') {
-        const allowed = ['@unphu.edu.do', '@gmail.com']
-        if (!allowed.some(domain => user.email?.endsWith(domain))) {
+        const allowedDomain = '@unphu.edu.do'
+        if (!user.email?.endsWith(allowedDomain)) {
           return false
         }
       }


### PR DESCRIPTION
## Summary
- limit Google sign-in to `@unphu.edu.do`
- prevent Google OAuth users with other domains from being created

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68682641d13c8327b30d57e034ab7add