### PR TITLE
Update auth forms layout

### DIFF
--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -1,6 +1,7 @@
 // pages/auth/signin.tsx
 import { useState, FormEvent } from 'react'
 import { FiLogIn } from 'react-icons/fi'
+import { FcGoogle } from 'react-icons/fc'
 import { getCsrfToken, signIn, getSession } from 'next-auth/react'
 import { GetServerSideProps } from 'next'
 import { useRouter } from 'next/router'
@@ -69,25 +70,27 @@ export default function SignIn({ csrfToken, confirmed }: Props) {
             required
           />
         </div>
-        <button type="submit" className="button primary large full-width signin-btn">
-          <FiLogIn /> Iniciar Sesión
-        </button>
+        <div className="button-row">
+          <button type="submit" className="button primary signin-btn">
+            <FiLogIn /> Iniciar Sesión
+          </button>
+          <Link href="/register" className="button secondary">
+            Registrarse
+          </Link>
+        </div>
+        <Link href="/auth/forgot-password" className="forgot-link">
+          Olvidé mi contraseña
+        </Link>
+        <p className="auth-alt-text">Puedes iniciar sesión con el siguiente servicio:</p>
         <button
           type="button"
-          className="button secondary large full-width"
+          className="google-icon-btn"
           onClick={() =>
             signIn('google', { callbackUrl: '/', prompt: 'select_account' })
           }
         >
-          Iniciar con Google
+          <FcGoogle size={24} />
         </button>
-        <Link href="/auth/forgot-password" className="button secondary large full-width">
-          Olvidé mi contraseña
-        </Link>
-        <div className="divider">¿No tienes cuenta?</div>
-        <Link href="/register" className="button secondary large full-width">
-          Registrarse
-        </Link>
       </form>
     </main>
   )

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { signIn } from 'next-auth/react';
 import { FiLogIn } from 'react-icons/fi';
+import { FcGoogle } from 'react-icons/fc';
 
 export default function Register() {
   const [form, setForm] = useState({
@@ -149,14 +150,15 @@ export default function Register() {
         >
           {submitting ? 'Registrando...' : 'Registrarse'}
         </button>
+        <p className="auth-alt-text">Puedes registrarte con:</p>
         <button
           type="button"
-          className="button secondary large full-width"
+          className="google-icon-btn"
           onClick={() =>
             signIn('google', { callbackUrl: '/', prompt: 'select_account' })
           }
         >
-          Registrarse con Google
+          <FcGoogle size={24} />
         </button>
 
         <div className="divider">¿Ya tienes cuenta?</div>

--- a/styles/global.css
+++ b/styles/global.css
@@ -205,6 +205,45 @@ nav {
   left: 200%;
 }
 
+/* -------------------------------------------------------------------------- */
+/* 6.5) Formularios de Autenticación                                           */
+/* -------------------------------------------------------------------------- */
+.button-row {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.forgot-link {
+  display: block;
+  margin: 0.75rem 0;
+  color: var(--accent);
+  text-decoration: none;
+}
+.forgot-link:hover {
+  text-decoration: underline;
+}
+
+.auth-alt-text {
+  margin: 0.75rem 0;
+  color: var(--muted);
+}
+
+.google-icon-btn {
+  background: var(--white);
+  border: none;
+  padding: 0.75rem;
+  border-radius: var(--radius);
+  box-shadow: 0 2px 8px var(--shadow-light);
+  cursor: pointer;
+  transition: transform 0.2s;
+}
+.google-icon-btn:hover {
+  transform: translateY(-2px);
+}
+
 /* ==========================================================================
    7) HERO
    ========================================================================== */


### PR DESCRIPTION
## Summary
- restyle sign-in page with side-by-side actions and Google icon button
- update register page Google sign-up button
- add new CSS helpers for auth forms

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_686832166acc8327b0b69625a7eb1169