### PR TITLE
Run prisma generate during builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ La variable `NEXT_PUBLIC_IDLE_TIMEOUT_MINUTES` controla los minutos de inactivid
 Al registrarse, se genera un token de verificación único que se almacena en la tabla `EmailVerificationToken` y expira a las 24 horas. El correo de bienvenida incluye un enlace con este token. El usuario debe abrirlo para activar su cuenta.
 
 Si el token es válido se marca la columna `confirmed` en `Usuario` y el registro del token se elimina.
+
+## Deployment
+
+El script de construccion ejecuta `prisma generate` para crear el cliente de Prisma. En Vercel se deben definir `DATABASE_URL` y demas variables de entorno antes de compilar.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
-    "start": "next start"
+    "build": "prisma generate && next build",
+    "start": "next start",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@hookform/resolvers": "2.x",
@@ -42,4 +43,4 @@
   "prisma": {
     "seed": "node prisma/seed.js"
   }
- }
+}


### PR DESCRIPTION
## Summary
- ensure Prisma client generation after package install and during builds
- document the new deployment requirement for Vercel

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d127660d88327a5c12cf436f9f2c1