### PR TITLE
Fix role checks

### DIFF
--- a/lib/admin.ts
+++ b/lib/admin.ts
@@ -4,7 +4,7 @@ import { getSession } from 'next-auth/react'
 
 export async function ensureAdmin(ctx: GetServerSidePropsContext) {
   const session = await getSession(ctx)
-  if (!session || (session.user as any).role !== 'ADMIN') {
+  if (!session || (session.user as any).rol !== 'ADMIN') {
     return { redirect: { destination: '/', permanent: false } }
   }
   return { session }

--- a/pages/api/informes/route.ts
+++ b/pages/api/informes/route.ts
@@ -44,7 +44,6 @@ export async function GET(request: Request) {
     if (
       !session ||
       ((session.user as any).rol !== 'ADMIN' &&
-        (session.user as any).role !== 'admin' &&
         session.user?.email !== 'superadmin@unphu.edu.do')
     ) {
       return NextResponse.json({ error: 'No autorizado' }, { status: 401 })

--- a/pages/api/solicitudes/[id].ts
+++ b/pages/api/solicitudes/[id].ts
@@ -8,7 +8,7 @@ import { sendStatusEmail } from "../../../lib/mailer";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const session = await getServerSession(req, res, authOptions);
-  if (!session || (session.user as any).role !== "ADMIN")
+  if (!session || (session.user as any).rol !== "ADMIN")
     return res.status(403).json({ error: "Solo admin" });
 
   const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -38,9 +38,9 @@ export default function SignIn({ csrfToken, confirmed }: Props) {
 
     // Login OK: obtenemos la sesión actual
     const session = await getSession()
-    const role = (session?.user as any)?.role
+    const rol = (session?.user as any)?.rol
 
-    if (role === 'ADMIN') {
+    if (rol === 'ADMIN') {
       router.push('/admin')
     } else {
       router.push('/')

--- a/pages/solicitudes/index.tsx
+++ b/pages/solicitudes/index.tsx
@@ -39,7 +39,7 @@ export default function SolicitudesPage() {
               <td>{new Date(s.fechaUso).toLocaleDateString()}</td>
               <td>{s.estado}</td>
               <td>
-                {s.estado === "PENDIENTE" && (sessionStorage.getItem("role")==="ADMIN") && (
+                {s.estado === "PENDIENTE" && (sessionStorage.getItem("rol")==="ADMIN") && (
                   <>
                     <button onClick={() => approve(s.id, "APROBADA")}>Aprobar</button>
                     <button onClick={() => approve(s.id, "RECHAZADA")}>Rechazar</button>


### PR DESCRIPTION
## Summary
- use `rol` field when checking admin session
- adjust admin check in informes route
- fix signin redirect based on `rol`
- read `rol` from sessionStorage on solicitudes page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d1612794c8327ad51bccba73be3b0