### PR TITLE
Add mustCreatePassword to user schema

### DIFF
--- a/prisma/migrations/20250708170333_add_must_create_password_flag/migration.sql
+++ b/prisma/migrations/20250708170333_add_must_create_password_flag/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE `Usuario` ADD COLUMN `mustCreatePassword` BOOLEAN NOT NULL DEFAULT false;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   apellido                String
   password                String
   confirmed               Boolean                  @default(false)
+  mustCreatePassword      Boolean                  @default(false)
   rol                     Rol                      @default(USER)
   solicitudes             Solicitud[]
   auditLogs               AuditLog[] // Relación inversa para logs de este usuario


### PR DESCRIPTION
## Summary
- add `mustCreatePassword` boolean field to User model
- create migration to add column to Usuario table

## Testing
- `npx prisma migrate dev --name add_must_create_password_flag` *(fails: Can't reach database server)*

------
https://chatgpt.com/codex/tasks/task_e_686d4ecb44888327bc5b9e56e0c8b3b1