### PR TITLE
Implement mustCreatePassword flow

### DIFF
--- a/lib/customPrismaAdapter.ts
+++ b/lib/customPrismaAdapter.ts
@@ -34,6 +34,7 @@ export function CustomPrismaAdapter(prisma: PrismaClient): Adapter {
           email: data.email!,
           password,
           confirmed: true,
+          mustCreatePassword: true,
         },
       })
 

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -49,6 +49,7 @@ export const authOptions: NextAuthOptions = {
           name: `${user.nombre} ${user.apellido}`,
           email: user.email,
           rol: user.rol,
+          mustCreatePassword: user.mustCreatePassword,
         } as any
       },
     }),
@@ -66,18 +67,27 @@ export const authOptions: NextAuthOptions = {
           return false
         }
       }
+
+      const dbUser = await prisma.user.findUnique({
+        where: { id: Number(user.id) },
+      })
+      if (dbUser?.mustCreatePassword) {
+        return '/auth/set-password'
+      }
       return true
     },
     // Guardamos el rol en el token
     async jwt({ token, user }) {
       if (user) {
         token.rol = (user as any).rol
+        token.mustCreatePassword = (user as any).mustCreatePassword
       }
       return token
     },
     // Lo exponemos en session.user.rol
     async session({ session, token }) {
       ;(session.user as any).rol = token.rol
+      ;(session.user as any).mustCreatePassword = token.mustCreatePassword
       return session
     },
   },

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -39,6 +39,12 @@ export default function SignIn({ csrfToken, confirmed }: Props) {
     // Login OK: obtenemos la sesión actual
     const session = await getSession()
     const rol = (session?.user as any)?.rol
+    const mustCreate = (session?.user as any)?.mustCreatePassword
+
+    if (mustCreate) {
+      router.push('/auth/set-password')
+      return
+    }
 
     if (rol === 'ADMIN') {
       router.push('/admin')

--- a/prisma/migrations/20250704121518_add_must_create_password/migration.sql
+++ b/prisma/migrations/20250704121518_add_must_create_password/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Usuario` ADD COLUMN `mustCreatePassword` BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   apellido                String
   password                String
   confirmed               Boolean                  @default(false)
+  mustCreatePassword      Boolean                  @default(false)
   rol                     Rol                      @default(USER)
   solicitudes             Solicitud[]
   auditLogs               AuditLog[] // Relación inversa para logs de este usuario


### PR DESCRIPTION
## Summary
- set `mustCreatePassword` flag when creating users in the custom Prisma adapter
- expose the new property through credential authorization and callbacks
- redirect to password creation on sign in when needed
- check session for this flag on the sign-in page
- add migration and schema field for the new property

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d4ecda078832789189aa9be483aa0