### PR TITLE
Add set password API and page

### DIFF
--- a/pages/api/auth/set-password.ts
+++ b/pages/api/auth/set-password.ts
@@ -1,0 +1,32 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getServerSession } from 'next-auth/next'
+import bcrypt from 'bcrypt'
+import { authOptions } from './[...nextauth]'
+import { prisma } from '../../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const session = await getServerSession(req, res, authOptions)
+  if (!session) return res.status(401).json({ message: 'No autorizado' })
+
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST'])
+    return res.status(405).end()
+  }
+
+  const { password, confirmPassword } = req.body as { password?: string; confirmPassword?: string }
+  if (!password || !confirmPassword) {
+    return res.status(400).json({ message: 'Datos incompletos' })
+  }
+  if (password !== confirmPassword) {
+    return res.status(400).json({ message: 'Las contraseñas no coinciden' })
+  }
+
+  const hash = await bcrypt.hash(password, 10)
+
+  await (prisma.user.update as any)({
+    where: { id: Number((session.user as any).id) },
+    data: { password: hash, mustCreatePassword: false } as any,
+  })
+
+  return res.status(200).json({ message: 'Contraseña actualizada' })
+}

--- a/pages/auth/set-password.tsx
+++ b/pages/auth/set-password.tsx
@@ -1,0 +1,87 @@
+import { useState } from 'react'
+import { GetServerSideProps } from 'next'
+import { getSession } from 'next-auth/react'
+import Link from 'next/link'
+import { FiLogIn } from 'react-icons/fi'
+
+export default function SetPassword() {
+  const [password, setPassword] = useState('')
+  const [confirm, setConfirm] = useState('')
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    if (password !== confirm) {
+      setError('Las contraseñas no coinciden')
+      return
+    }
+    setSubmitting(true)
+    const res = await fetch('/api/auth/set-password', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password, confirmPassword: confirm }),
+    })
+    const data = await res.json()
+    setSubmitting(false)
+    if (!res.ok) {
+      setError(data.message)
+    } else {
+      setMessage('Contraseña actualizada correctamente.')
+    }
+  }
+
+  if (message) {
+    return (
+      <main className="register-page">
+        <h2>Crear contraseña</h2>
+        <p className="subheading">{message}</p>
+        <Link href="/auth/signin" className="button primary signin-btn">
+          <FiLogIn /> Iniciar Sesión
+        </Link>
+      </main>
+    )
+  }
+
+  return (
+    <main className="register-page">
+      <h2>Crear contraseña</h2>
+      <form className="form-card" onSubmit={handleSubmit}>
+        {error && <p style={{ color: 'red', marginBottom: '1rem' }}>{error}</p>}
+        <div className="form-group">
+          <label>Nueva contraseña</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            minLength={6}
+            required
+          />
+        </div>
+        <div className="form-group">
+          <label>Confirmar contraseña</label>
+          <input
+            type="password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            minLength={6}
+            required
+          />
+        </div>
+        <button type="submit" className="button primary large full-width" disabled={submitting}>
+          {submitting ? 'Actualizando...' : 'Guardar'}
+        </button>
+      </form>
+    </main>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  const session = await getSession(ctx)
+  if (!session?.user) {
+    return { redirect: { destination: '/auth/signin', permanent: false } }
+  }
+  return { props: {} }
+}


### PR DESCRIPTION
## Summary
- add `/api/auth/set-password` endpoint to update user password
- add `/auth/set-password` page for logged-in users to create a password

## Testing
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d4ecec4e4832790dd08380d9c9e24