### PR TITLE
Add mustCreatePassword defaults

### DIFF
--- a/pages/api/admin/users/index.ts
+++ b/pages/api/admin/users/index.ts
@@ -37,7 +37,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     try {
       const hash = await bcrypt.hash(password, 10)
       const created = await prisma.user.create({
-        data: { matricula, nombre, apellido, email, rol, password: hash, confirmed: true },
+        data: { matricula, nombre, apellido, email, rol, password: hash, confirmed: true, mustCreatePassword: false },
         select: {
           id: true,
           matricula: true,

--- a/pages/api/auth/reset-password.ts
+++ b/pages/api/auth/reset-password.ts
@@ -25,7 +25,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   const hash = await bcrypt.hash(password, 10)
   await prisma.user.update({
     where: { id: record.userId },
-    data: { password: hash },
+    data: { password: hash, mustCreatePassword: false },
   })
   await prisma.passwordResetToken.delete({ where: { id: record.id } })
 

--- a/pages/api/register.ts
+++ b/pages/api/register.ts
@@ -39,6 +39,7 @@ export default async function handler(
         apellido,
         password: hashed,
         rol: 'USER',
+        mustCreatePassword: false,
       },
     });
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   apellido                String
   password                String
   confirmed               Boolean                  @default(false)
+  mustCreatePassword      Boolean                  @default(false)
   rol                     Rol                      @default(USER)
   solicitudes             Solicitud[]
   auditLogs               AuditLog[] // Relación inversa para logs de este usuario

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -17,6 +17,7 @@ async function main() {
       password: hash,
       confirmed: true,
       rol: 'ADMIN',
+      mustCreatePassword: false,
     },
   })
 


### PR DESCRIPTION
## Summary
- add `mustCreatePassword` property to `User` schema
- set `mustCreatePassword: false` when resetting password
- ensure new users start with `mustCreatePassword: false`
- seed admin user with `mustCreatePassword: false`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d4ecf7a4c83278d6a213af37d5c0b