### PR TITLE
Fix google sign-in user lookup

### DIFF
--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -69,7 +69,7 @@ export const authOptions: NextAuthOptions = {
       }
 
       const dbUser = await prisma.user.findUnique({
-        where: { id: Number(user.id) },
+        where: { email: user.email! },
       })
       if (dbUser?.mustCreatePassword) {
         return '/auth/set-password'


### PR DESCRIPTION
## Summary
- fix Google login by fetching DB user via email in signIn callback

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d561c5ae88327b68e3e8d7ac949b7