### PR TITLE
Fix Google sign-in redirect

### DIFF
--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -91,9 +91,13 @@ export default function SignIn({ csrfToken, confirmed }: Props) {
         <button
           type="button"
           className="google-icon-btn"
-          onClick={() =>
-            signIn('google', { callbackUrl: '/', prompt: 'select_account' })
-          }
+          onClick={async () => {
+            const res = await signIn('google', {
+              redirect: false,
+              prompt: 'select_account',
+            })
+            if (res?.url) router.push(res.url)
+          }}
         >
           <FcGoogle size={24} />
         </button>


### PR DESCRIPTION
## Summary
- ensure Google sign-in redirects to the URL returned by NextAuth

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d58ccbe388327bef191e9110e636a