### PR TITLE
Add user profile page and default Gmail password

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,10 @@ npx prisma-erd-generator --schema prisma/schema.prisma --output prisma/ERD.svg -
 
 Se generara `prisma/ERD.svg` con el modelo actual.
 
+## Perfil de usuario
+
+Al registrarse mediante Google, la aplicación asigna por defecto la contraseña
+`{matrícula}@2020` (siendo la parte antes del `@` en su correo). Esta y los
+datos de nombre pueden actualizarse luego desde la nueva página **Mi Perfil**
+disponible en el menú principal.
+

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -58,6 +58,11 @@ export default function Layout({ children }: Props) {
                         Reporte
                       </Link>
                     </li>
+                    <li>
+                      <Link href="/perfil" className="nav-link">
+                        Perfil
+                      </Link>
+                    </li>
                   </>
                 ) : (
                   <>
@@ -74,6 +79,11 @@ export default function Layout({ children }: Props) {
                     <li>
                       <Link href="/nueva-solicitud" className="nav-link">
                         Nueva Solicitud
+                      </Link>
+                    </li>
+                    <li>
+                      <Link href="/perfil" className="nav-link">
+                        Perfil
                       </Link>
                     </li>
                     <li>

--- a/lib/customPrismaAdapter.ts
+++ b/lib/customPrismaAdapter.ts
@@ -24,7 +24,9 @@ export function CustomPrismaAdapter(prisma: PrismaClient): Adapter {
       const matricula = data.email
         ? data.email.split('@')[0]
         : randomBytes(6).toString('hex')
-      const password = await bcrypt.hash(randomBytes(16).toString('hex'), 10)
+      // Establecemos la contraseña por defecto con el formato "{matricula}@2020"
+      const defaultPassword = `${matricula}@2020`
+      const password = await bcrypt.hash(defaultPassword, 10)
 
       const user = await prisma.user.create({
         data: {
@@ -34,7 +36,9 @@ export function CustomPrismaAdapter(prisma: PrismaClient): Adapter {
           email: data.email!,
           password,
           confirmed: true,
-          mustCreatePassword: true,
+          // El usuario ya tiene una contraseña asignada, por lo que no
+          // requerimos que cree una al iniciar sesión
+          mustCreatePassword: false,
         },
       })
 

--- a/pages/api/profile.ts
+++ b/pages/api/profile.ts
@@ -1,0 +1,43 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { getToken } from 'next-auth/jwt'
+import bcrypt from 'bcrypt'
+import { prisma } from '../../lib/prisma'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
+  if (!token) return res.status(401).json({ message: 'No autorizado' })
+
+  const userId = Number(token.sub)
+
+  if (req.method === 'GET') {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { nombre: true, apellido: true, email: true, matricula: true },
+    })
+    return res.status(200).json(user)
+  }
+
+  if (req.method === 'PATCH' || req.method === 'POST') {
+    const { nombre, apellido, password, confirmPassword } = req.body as {
+      nombre?: string
+      apellido?: string
+      password?: string
+      confirmPassword?: string
+    }
+    if (!nombre || !apellido) {
+      return res.status(400).json({ message: 'Faltan campos obligatorios' })
+    }
+    const data: any = { nombre, apellido }
+    if (password || confirmPassword) {
+      if (password !== confirmPassword) {
+        return res.status(400).json({ message: 'Las contraseñas no coinciden' })
+      }
+      data.password = await bcrypt.hash(password!, 10)
+    }
+    await prisma.user.update({ where: { id: userId }, data })
+    return res.status(200).json({ message: 'Perfil actualizado' })
+  }
+
+  res.setHeader('Allow', ['GET', 'PATCH'])
+  res.status(405).end()
+}

--- a/pages/perfil.tsx
+++ b/pages/perfil.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react'
+import Layout from '../components/Layout'
+import { GetServerSideProps } from 'next'
+import { getSession } from 'next-auth/react'
+import { prisma } from '../lib/prisma'
+
+type Props = {
+  nombre: string
+  apellido: string
+}
+
+export default function Perfil({ nombre, apellido }: Props) {
+  const [form, setForm] = useState({
+    nombre,
+    apellido,
+    password: '',
+    confirm: '',
+  })
+  const [message, setMessage] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setForm(f => ({ ...f, [e.target.name]: e.target.value }))
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    if (form.password && form.password !== form.confirm) {
+      setError('Las contraseñas no coinciden')
+      return
+    }
+    setLoading(true)
+    const res = await fetch('/api/profile', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        nombre: form.nombre,
+        apellido: form.apellido,
+        password: form.password,
+        confirmPassword: form.confirm,
+      }),
+    })
+    const data = await res.json()
+    setLoading(false)
+    if (!res.ok) {
+      setError(data.message || 'Error al actualizar')
+    } else {
+      setMessage('Perfil actualizado correctamente')
+      setForm(f => ({ ...f, password: '', confirm: '' }))
+    }
+  }
+
+  return (
+    <Layout>
+      <section className="page-center">
+        <div className="form-card">
+          <h2>Mi Perfil</h2>
+          {message && (
+            <p className="subheading" style={{ color: '#2ecc71' }}>{message}</p>
+          )}
+          <form onSubmit={handleSubmit} className="form-grid">
+            {error && <p className="error-text">{error}</p>}
+            <label>Nombre</label>
+            <input
+              name="nombre"
+              value={form.nombre}
+              onChange={handleChange}
+              required
+            />
+            <label>Apellido</label>
+            <input
+              name="apellido"
+              value={form.apellido}
+              onChange={handleChange}
+              required
+            />
+            <label>Nueva contraseña</label>
+            <input
+              type="password"
+              name="password"
+              value={form.password}
+              onChange={handleChange}
+            />
+            <label>Confirmar contraseña</label>
+            <input
+              type="password"
+              name="confirm"
+              value={form.confirm}
+              onChange={handleChange}
+            />
+            <button type="submit" className="button primary" disabled={loading}>
+              {loading ? 'Actualizando...' : 'Guardar Cambios'}
+            </button>
+          </form>
+        </div>
+      </section>
+    </Layout>
+  )
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async ctx => {
+  const session = await getSession(ctx)
+  if (!session?.user?.email) {
+    return { redirect: { destination: '/auth/signin', permanent: false } }
+  }
+  const user = await prisma.user.findUnique({
+    where: { email: session.user.email },
+    select: { nombre: true, apellido: true },
+  })
+  if (!user) {
+    return { redirect: { destination: '/auth/signin', permanent: false } }
+  }
+  return { props: { nombre: user.nombre, apellido: user.apellido } }
+}


### PR DESCRIPTION
## Summary
- set default password when registering via Google
- allow updating profile and password from new page
- link to profile in navigation
- document new feature

## Testing
- `npm install`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_686d692b7bec832792ff177620d973cd