### PR TITLE
Add responsive mobile nav

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,5 +1,5 @@
 // components/Layout.tsx
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useSession, signOut } from 'next-auth/react';
 import { useRouter } from 'next/router';
@@ -9,6 +9,15 @@ type Props = { children: ReactNode };
 export default function Layout({ children }: Props) {
   const { data: session, status } = useSession();
   const router = useRouter();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    const handleRouteChange = () => setMenuOpen(false);
+    router.events.on('routeChangeStart', handleRouteChange);
+    return () => {
+      router.events.off('routeChangeStart', handleRouteChange);
+    };
+  }, [router]);
   if (status === 'loading') return null;
 
   const user = session?.user as { rol?: string; name?: string };
@@ -23,8 +32,15 @@ export default function Layout({ children }: Props) {
             <Link href={logoHref} className="logo">
               UNPHU Inventario
             </Link>
+            <button
+              className="nav-toggle"
+              onClick={() => setMenuOpen((o) => !o)}
+              aria-label="Menú"
+            >
+              ☰
+            </button>
             <nav>
-              <ul className="nav-list">
+              <ul className={`nav-list${menuOpen ? ' open' : ''}`}>
                 {isAdmin ? (
                   <>
                     <li>

--- a/styles/global.css
+++ b/styles/global.css
@@ -89,6 +89,14 @@ nav {
   flex: 1;
   margin: 0 2rem;
 }
+.nav-toggle {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--white);
+  font-size: 1.75rem;
+  cursor: pointer;
+}
 .nav-list {
   display: flex;
   gap: 1.5rem;
@@ -108,6 +116,9 @@ nav {
 .nav-link:hover,
 .nav-link.active {
   background: rgba(255, 255, 255, 0.2);
+}
+.nav-list.open {
+  display: flex;
 }
 
 .session-info {
@@ -557,7 +568,28 @@ footer {
   }
   header .app-container.header-flex {
     flex-direction: column;
-    gap: 1rem;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+  .nav-toggle {
+    display: block;
+    margin-left: auto;
+  }
+  nav {
+    width: 100%;
+  }
+  .nav-list {
+    flex-direction: column;
+    width: 100%;
+    gap: 0.5rem;
+    display: none;
+  }
+  .nav-list li {
+    text-align: left;
+  }
+  .session-info {
+    width: 100%;
+    justify-content: flex-end;
   }
   .features {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- make navigation collapsible with a hamburger button
- hide/show nav-list with mobile styles
- tweak header-flex responsiveness

## Testing
- `npx tsc -p tsconfig.json`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ebd4f5a888327ab5f32f174fa544a