### PR TITLE
Add responsive scroll wrappers for minimal tables

### DIFF
--- a/pages/admin/audit.tsx
+++ b/pages/admin/audit.tsx
@@ -43,7 +43,8 @@ export default function AuditPage({ logs }: Props) {
     <Layout>
       <section className="app-container">
         <h2>Historial de Auditoría</h2>
-        <table className="table-minimal">
+        <div style={{ overflowX: 'auto' }}>
+          <table className="table-minimal">
           <thead>
             <tr>
               <th>Fecha</th>
@@ -66,7 +67,8 @@ export default function AuditPage({ logs }: Props) {
               </tr>
             ))}
           </tbody>
-        </table>
+          </table>
+        </div>
       </section>
     </Layout>
   )

--- a/pages/admin/departments.tsx
+++ b/pages/admin/departments.tsx
@@ -196,7 +196,8 @@ export default function AdminDepartments({ departamentos, usuarios }: Props) {
       )}
 
       <section className="app-container">
-        <table className="table-minimal">
+        <div style={{ overflowX: 'auto' }}>
+          <table className="table-minimal">
           <thead>
             <tr>
               <th>Nombre</th>
@@ -231,7 +232,8 @@ export default function AdminDepartments({ departamentos, usuarios }: Props) {
               </tr>
             ))}
           </tbody>
-        </table>
+          </table>
+        </div>
       </section>
     </Layout>
   )

--- a/pages/admin/items.tsx
+++ b/pages/admin/items.tsx
@@ -280,7 +280,8 @@ export default function AdminItems({
       )}
 
       <section className="app-container">
-        <table className="table-minimal">
+        <div style={{ overflowX: 'auto' }}>
+          <table className="table-minimal">
           <thead>
             <tr>
               <th>Nombre</th>
@@ -314,7 +315,8 @@ export default function AdminItems({
               </tr>
             ))}
           </tbody>
-        </table>
+          </table>
+        </div>
       </section>
     </Layout>
   )

--- a/pages/admin/requests.tsx
+++ b/pages/admin/requests.tsx
@@ -105,7 +105,8 @@ export default function AdminRequestsPage() {
           </button>
         </div>
 
-        <table className="table-minimal">
+        <div style={{ overflowX: 'auto' }}>
+          <table className="table-minimal">
           <thead>
             <tr>
               <th>Fecha</th>
@@ -148,7 +149,8 @@ export default function AdminRequestsPage() {
               </tr>
             ))}
           </tbody>
-        </table>
+          </table>
+        </div>
       </section>
     </Layout>
   )

--- a/pages/admin/users.tsx
+++ b/pages/admin/users.tsx
@@ -160,7 +160,8 @@ export default function AdminUsers({ users }: Props) {
       </section>
 
       <section className="app-container">
-        <table className="table-minimal">
+        <div style={{ overflowX: 'auto' }}>
+          <table className="table-minimal">
           <thead>
             <tr>
               <th>Matrícula</th>
@@ -196,7 +197,8 @@ export default function AdminUsers({ users }: Props) {
               </tr>
             ))}
           </tbody>
-        </table>
+          </table>
+        </div>
       </section>
 
       {showModal && (

--- a/pages/mis-solicitudes.tsx
+++ b/pages/mis-solicitudes.tsx
@@ -91,6 +91,7 @@ export default function MisSolicitudes() {
         ) : solicitudes.length === 0 ? (
           <p>No tienes solicitudes para mostrar.</p>
         ) : (
+          <div style={{ overflowX: 'auto' }}>
           <table className="table-minimal">
             <thead>
               <tr>
@@ -179,6 +180,7 @@ export default function MisSolicitudes() {
               })}
             </tbody>
           </table>
+          </div>
         )}
       </section>
     </Layout>

--- a/styles/global.css
+++ b/styles/global.css
@@ -562,4 +562,7 @@ footer {
   .features {
     grid-template-columns: 1fr;
   }
+  .table-minimal {
+    display: block;
+  }
 }


### PR DESCRIPTION
## Summary
- wrap admin tables in overflow containers to enable horizontal scroll
- allow `.table-minimal` to display as block on small screens

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ebd503f5483278929d00fa341d94b