### PR TITLE
Add button sizing utility classes

### DIFF
--- a/pages/solicitudes/index.tsx
+++ b/pages/solicitudes/index.tsx
@@ -41,8 +41,18 @@ export default function SolicitudesPage() {
               <td>
                 {s.estado === "PENDIENTE" && (sessionStorage.getItem("rol")==="ADMIN") && (
                   <>
-                    <button onClick={() => approve(s.id, "APROBADA")}>Aprobar</button>
-                    <button onClick={() => approve(s.id, "RECHAZADA")}>Rechazar</button>
+                    <button
+                      className="btn btn-small btn-primary"
+                      onClick={() => approve(s.id, "APROBADA")}
+                    >
+                      Aprobar
+                    </button>
+                    <button
+                      className="btn btn-small btn-secondary"
+                      onClick={() => approve(s.id, "RECHAZADA")}
+                    >
+                      Rechazar
+                    </button>
                   </>
                 )}
               </td>

--- a/styles/global.css
+++ b/styles/global.css
@@ -183,6 +183,16 @@ nav {
   font-size: 1.1rem;
 }
 
+.btn-small {
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+}
+
+.btn-lg {
+  padding: 1rem 1.5rem;
+  font-size: 1.1rem;
+}
+
 .button.signin-btn {
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
## Summary
- add `.btn-small` and `.btn-lg` rules to `global.css`
- apply small button classes to approve/reject actions in solicitudes page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ebd5081608327a948b306ddb290c7