### PR TITLE
Adjust heading sizes on small screens

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -562,4 +562,14 @@ footer {
   .features {
     grid-template-columns: 1fr;
   }
+  .hero h2 {
+    font-size: 1.75rem;
+  }
+  .card-title,
+  .card h4 {
+    font-size: 1rem;
+  }
+  .register-page h2 {
+    font-size: 1.5rem;
+  }
 }


### PR DESCRIPTION
## Summary
- tweak mobile font sizes for hero and card sections

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ebd5158488327b1af5b69923b7bf5