### PR TITLE
Fix long usernames hiding logout button

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -130,6 +130,10 @@ nav {
 .session-user {
   font-weight: 500;
   color: var(--white);
+  max-width: 12ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .btn-logout {
   padding: 0.5rem 1rem;


### PR DESCRIPTION
## Summary
- prevent extremely long usernames from pushing out logout button by truncating text

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `prisma: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ecb43bff48327be8d7fe97d5e92b2