### PR TITLE
Update color scheme to official UNPHU palette

### DIFF
--- a/components/Landing.tsx
+++ b/components/Landing.tsx
@@ -56,19 +56,19 @@ export default function Landing() {
         <div className="features">
           {[
             {
-              icon: <FiBox size={32} color="#16A085" />,
+              icon: <FiBox size={32} color="var(--accent)" />,
               title: 'Gestión de Inventario',
               text:
                 'Control completo de los equipos disponibles en los departamentos de Audiovisual y Tecnología.',
             },
             {
-              icon: <FiClipboard size={32} color="#16A085" />,
+              icon: <FiClipboard size={32} color="var(--accent)" />,
               title: 'Solicitudes de Préstamo',
               text:
                 'Solicita equipos de forma fácil y rápida especificando fechas, horas y motivo de uso.',
             },
             {
-              icon: <FiCheckSquare size={32} color="#16A085" />,
+              icon: <FiCheckSquare size={32} color="var(--accent)" />,
               title: 'Aprobación de Solicitudes',
               text:
                 'Sistema de aprobación para administradores con seguimiento del estado de cada solicitud.',

--- a/pages/admin/index.tsx
+++ b/pages/admin/index.tsx
@@ -25,35 +25,35 @@ export default function AdminDashboard({ name }: Props) {
       <section className="features">
         <Link href="/admin/requests" className="card-wrapper">
           <div className="card">
-            <FiFileText size={32} color="#3498db" />
+            <FiFileText size={32} color="var(--accent)" />
             <h4>Solicitudes</h4>
             <p>Revisar y aprobar/rechazar</p>
           </div>
         </Link>
         <Link href="/admin/users" className="card-wrapper">
           <div className="card">
-            <FiUserPlus size={32} color="#16A085" />
+            <FiUserPlus size={32} color="var(--accent)" />
             <h4>Usuarios</h4>
             <p>Crear y gestionar usuarios</p>
           </div>
         </Link>
         <Link href="/admin/departments" className="card-wrapper">
           <div className="card">
-            <FiHome size={32} color="#f39c12" />
+            <FiHome size={32} color="var(--accent)" />
             <h4>Departamentos</h4>
             <p>Crear/editar departamentos</p>
           </div>
         </Link>
         <Link href="/admin/items" className="card-wrapper">
           <div className="card">
-            <FiBox size={32} color="#2ecc71" />
+            <FiBox size={32} color="var(--accent)" />
             <h4>Equipos</h4>
             <p>Registrar/editar equipos</p>
           </div>
         </Link>
 <Link href="/admin/audit" className="card-wrapper">
   <div className="card">
-    <FiClipboard size={32} color="#9b59b6" />
+    <FiClipboard size={32} color="var(--accent)" />
     <h4>Auditoría</h4>
     <p>Ver historial de cambios</p>
   </div>

--- a/styles/global.css
+++ b/styles/global.css
@@ -18,8 +18,8 @@
   --bg: #f5f5f5;
   --surface: #ffffff;
   --text: #1f2937;
-  --primary: #165C4F;
-  --accent: #16A085;
+  --primary: #439441;
+  --accent: #0F385A;
   --white: #ffffff;
   --muted: #777777;
   --border: #e5e7eb;


### PR DESCRIPTION
## Summary
- set primary and accent CSS vars to official branding colors
- use CSS vars for feature icons in landing page
- update admin dashboard icons to use accent color

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68713cd2d53c8327b28ea04a84e48402