### PR TITLE
Fix department user data

### DIFF
--- a/pages/api/admin/departamentos/[id].ts
+++ b/pages/api/admin/departamentos/[id].ts
@@ -37,7 +37,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       const updated = await prisma.departamento.update({
         where: { id: depId },
         data,
-        include: { usuarios: { select: { id: true } } },
+        include: { usuarios: { select: { id: true, nombre: true, apellido: true } } },
       })
       await prisma.auditLog.create({
         data: {

--- a/pages/api/admin/departamentos/index.ts
+++ b/pages/api/admin/departamentos/index.ts
@@ -20,13 +20,24 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   // 3) Crear nuevo departamento
   if (req.method === 'POST') {
-    const { nombre, descripcion } = req.body
+    const { nombre, descripcion, usuarios } = req.body
     if (!nombre) {
       return res.status(400).json({ message: 'Falta nombre' })
     }
     try {
       const created = await prisma.departamento.create({
-        data: { nombre, descripcion: descripcion || undefined },
+        data: {
+          nombre,
+          descripcion: descripcion || undefined,
+          ...(Array.isArray(usuarios) && usuarios.length
+            ? {
+                usuarios: {
+                  connect: usuarios.map((uid: number) => ({ id: uid })),
+                },
+              }
+            : {}),
+        },
+        include: { usuarios: { select: { id: true, nombre: true, apellido: true } } },
       })
       return res.status(201).json(created)
     } catch (e: any) {


### PR DESCRIPTION
## Summary
- include assigned users when creating or updating a department so the admin UI doesn't fail

## Testing
- `npm run build`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68878c964fec832781f2a03b78b3eed8