### PR TITLE
Standardize Layout use across pages

### DIFF
--- a/components/Dashboard.tsx
+++ b/components/Dashboard.tsx
@@ -10,18 +10,6 @@ type DashboardProps = {
 export default function Dashboard({ name, counts }: DashboardProps) {
   return (
     <>
-      <header>
-        <div className="app-container">
-          <h1>UNPHU Inventario</h1>
-          {/* Los botones de login/registro ya están ocultos desde Layout */}
-          <div style={{ textAlign: 'right' }}>
-            <Link href="/nueva-solicitud" className="button primary">
-              Nueva Solicitud
-            </Link>
-          </div>
-        </div>
-      </header>
-
       <section className="app-container" style={{ padding: '2rem 1rem' }}>
         <h2>¡Bienvenido, {name}!</h2>
         <p style={{ color: '#555' }}>
@@ -69,13 +57,6 @@ export default function Dashboard({ name, counts }: DashboardProps) {
           </li>
         </ol>
       </section>
-
-      <footer>
-        <div className="app-container">
-          <span>© {new Date().getFullYear()} UNPHU – Sistema de Inventario</span>
-          <span>República Dominicana</span>
-        </div>
-      </footer>
     </>
   )
 }

--- a/pages/admin/informes/page.tsx
+++ b/pages/admin/informes/page.tsx
@@ -5,6 +5,7 @@ import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import { PDFDownloadLink } from '@react-pdf/renderer'
 import InformePDF from '@/components/InformePDF'
+import Layout from '../../../components/Layout'
 
 type Equipo = {
   id: number
@@ -111,19 +112,22 @@ export default function InformesPage() {
 
   if (status === 'loading') {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-green-700" />
-      </div>
+      <Layout>
+        <div className="flex items-center justify-center h-64">
+          <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-green-700" />
+        </div>
+      </Layout>
     )
   }
 
   if (status === 'unauthenticated' || (session && (session.user as any).rol !== 'ADMIN')) {
-    return null
+    return <Layout><p className="p-4">Acceso no autorizado</p></Layout>
   }
 
   return (
-    <div className="bg-gray-50 min-h-screen py-6">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <Layout>
+      <div className="bg-gray-50 min-h-screen py-6">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Título y botón “Volver a Solicitudes” */}
         <div className="md:flex md:items-center md:justify-between mb-8">
           <div className="min-w-0 flex-1">
@@ -479,5 +483,6 @@ export default function InformesPage() {
         )}
       </div>
     </div>
+    </Layout>
   )
 }

--- a/pages/auth/forgot-password.tsx
+++ b/pages/auth/forgot-password.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { FiLogIn } from 'react-icons/fi'
+import Layout from '../../components/Layout'
 
 export default function ForgotPassword() {
   const [email, setEmail] = useState('')
@@ -29,18 +30,21 @@ export default function ForgotPassword() {
 
   if (message) {
     return (
-      <main className="register-page">
-        <h2>Recuperar contraseña</h2>
-        <p className="subheading">{message}</p>
-        <Link href="/auth/signin" className="button primary signin-btn">
-          <FiLogIn /> Iniciar Sesión
-        </Link>
-      </main>
+      <Layout>
+        <main className="register-page">
+          <h2>Recuperar contraseña</h2>
+          <p className="subheading">{message}</p>
+          <Link href="/auth/signin" className="button primary signin-btn">
+            <FiLogIn /> Iniciar Sesión
+          </Link>
+        </main>
+      </Layout>
     )
   }
 
   return (
-    <main className="register-page">
+    <Layout>
+      <main className="register-page">
       <h2>¿Olvidaste tu contraseña?</h2>
       <p className="subheading">Ingresa tu correo para recibir instrucciones</p>
       <form className="form-card" onSubmit={handleSubmit}>
@@ -62,5 +66,6 @@ export default function ForgotPassword() {
         </Link>
       </form>
     </main>
+    </Layout>
   )
 }

--- a/pages/auth/reset-password.tsx
+++ b/pages/auth/reset-password.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
 import { FiLogIn } from 'react-icons/fi'
+import Layout from '../../components/Layout'
 
 export default function ResetPassword() {
   const router = useRouter()
@@ -38,32 +39,37 @@ export default function ResetPassword() {
 
   if (!tokenParam && router.isReady) {
     return (
-      <main className="register-page">
-        <h2>Cambiar contraseña</h2>
-        <p className="subheading">
-          El enlace de recuperación no es válido o ha expirado.
-        </p>
-        <Link href="/auth/forgot-password" className="button primary">
-          Solicitar nuevo enlace
-        </Link>
-      </main>
+      <Layout>
+        <main className="register-page">
+          <h2>Cambiar contraseña</h2>
+          <p className="subheading">
+            El enlace de recuperación no es válido o ha expirado.
+          </p>
+          <Link href="/auth/forgot-password" className="button primary">
+            Solicitar nuevo enlace
+          </Link>
+        </main>
+      </Layout>
     )
   }
 
   if (message) {
     return (
-      <main className="register-page">
-        <h2>Cambiar contraseña</h2>
-        <p className="subheading">{message}</p>
-        <Link href="/auth/signin" className="button primary signin-btn">
-          <FiLogIn /> Iniciar Sesión
-        </Link>
-      </main>
+      <Layout>
+        <main className="register-page">
+          <h2>Cambiar contraseña</h2>
+          <p className="subheading">{message}</p>
+          <Link href="/auth/signin" className="button primary signin-btn">
+            <FiLogIn /> Iniciar Sesión
+          </Link>
+        </main>
+      </Layout>
     )
   }
 
   return (
-    <main className="register-page">
+    <Layout>
+      <main className="register-page">
       <h2>Cambiar contraseña</h2>
       <form className="form-card" onSubmit={handleSubmit}>
         {error && <p style={{ color: 'red', marginBottom: '1rem' }}>{error}</p>}
@@ -92,5 +98,6 @@ export default function ResetPassword() {
         </button>
       </form>
     </main>
+    </Layout>
   )
 }

--- a/pages/auth/set-password.tsx
+++ b/pages/auth/set-password.tsx
@@ -3,6 +3,7 @@ import { GetServerSideProps } from 'next'
 import { getSession } from 'next-auth/react'
 import Link from 'next/link'
 import { FiLogIn } from 'react-icons/fi'
+import Layout from '../../components/Layout'
 
 export default function SetPassword() {
   const [password, setPassword] = useState('')
@@ -35,18 +36,21 @@ export default function SetPassword() {
 
   if (message) {
     return (
-      <main className="register-page">
-        <h2>Crear contraseña</h2>
-        <p className="subheading">{message}</p>
-        <Link href="/auth/signin" className="button primary signin-btn">
-          <FiLogIn /> Iniciar Sesión
-        </Link>
-      </main>
+      <Layout>
+        <main className="register-page">
+          <h2>Crear contraseña</h2>
+          <p className="subheading">{message}</p>
+          <Link href="/auth/signin" className="button primary signin-btn">
+            <FiLogIn /> Iniciar Sesión
+          </Link>
+        </main>
+      </Layout>
     )
   }
 
   return (
-    <main className="register-page">
+    <Layout>
+      <main className="register-page">
       <h2>Crear contraseña</h2>
       <form className="form-card" onSubmit={handleSubmit}>
         {error && <p style={{ color: 'red', marginBottom: '1rem' }}>{error}</p>}
@@ -75,6 +79,7 @@ export default function SetPassword() {
         </button>
       </form>
     </main>
+    </Layout>
   )
 }
 

--- a/pages/auth/signin.tsx
+++ b/pages/auth/signin.tsx
@@ -6,6 +6,7 @@ import { getCsrfToken, signIn, getSession } from 'next-auth/react'
 import { GetServerSideProps } from 'next'
 import { useRouter } from 'next/router'
 import Link from 'next/link'
+import Layout from '../../components/Layout'
 
 type Props = {
   csrfToken: string | null
@@ -54,7 +55,8 @@ export default function SignIn({ csrfToken, confirmed }: Props) {
   }
 
   return (
-    <main className="register-page">
+    <Layout>
+      <main className="register-page">
       <h2>Iniciar Sesión</h2>
       {msg && <p className="subheading" style={{ color: msg.includes('incorrecta') ? 'red' : undefined }}>{msg}</p>}
       <form className="form-card" onSubmit={handleSubmit}>
@@ -103,6 +105,7 @@ export default function SignIn({ csrfToken, confirmed }: Props) {
         </button>
       </form>
     </main>
+    </Layout>
   )
 }
 

--- a/pages/departamentos/index.tsx
+++ b/pages/departamentos/index.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from "axios";
 import { DepartmentForm } from "../../components/DepartmentForm";
+import Layout from "../../components/Layout";
 
 export default function DeptPage() {
   const { data, refetch } = useQuery({
@@ -9,7 +10,8 @@ export default function DeptPage() {
   });
 
   return (
-    <div>
+    <Layout>
+      <div className="main-content">
       <h1>Departamentos</h1>
       <DepartmentForm onSaved={refetch} />
       <ul>
@@ -20,6 +22,7 @@ export default function DeptPage() {
           </li>
         ))}
       </ul>
-    </div>
+      </div>
+    </Layout>
   );
 }

--- a/pages/register.tsx
+++ b/pages/register.tsx
@@ -5,6 +5,7 @@ import { signIn } from 'next-auth/react';
 import { useRouter } from 'next/router';
 import { FiLogIn } from 'react-icons/fi';
 import { FcGoogle } from 'react-icons/fc';
+import Layout from '../components/Layout';
 
 export default function Register() {
   const router = useRouter();
@@ -58,18 +59,21 @@ export default function Register() {
 
   if (submittedMessage) {
     return (
-      <main className="register-page">
-        <h2>¡Registro exitoso!</h2>
-        <p className="subheading">{submittedMessage}</p>
-        <Link href="/auth/signin" className="button primary signin-btn">
-          <FiLogIn /> Ir a Iniciar Sesión
-        </Link>
-      </main>
+      <Layout>
+        <main className="register-page">
+          <h2>¡Registro exitoso!</h2>
+          <p className="subheading">{submittedMessage}</p>
+          <Link href="/auth/signin" className="button primary signin-btn">
+            <FiLogIn /> Ir a Iniciar Sesión
+          </Link>
+        </main>
+      </Layout>
     );
   }
 
   return (
-    <main className="register-page">
+    <Layout>
+      <main className="register-page">
       <h2>Crear cuenta</h2>
       <p className="subheading">Sistema de Inventario UNPHU</p>
       <form className="form-card" onSubmit={handleSubmit}>
@@ -174,5 +178,6 @@ export default function Register() {
         </Link>
       </form>
     </main>
+    </Layout>
   );
 }

--- a/pages/registro-exitoso.tsx
+++ b/pages/registro-exitoso.tsx
@@ -2,6 +2,7 @@ import { GetServerSideProps } from 'next'
 import { getSession } from 'next-auth/react'
 import Link from 'next/link'
 import { FiHome } from 'react-icons/fi'
+import Layout from '../components/Layout'
 
 type Props = {
   defaultPassword: string
@@ -9,16 +10,18 @@ type Props = {
 
 export default function RegistroExitoso({ defaultPassword }: Props) {
   return (
-    <main className="register-page">
-      <h2>¡Registro exitoso!</h2>
-      <p className="subheading">
-        Tu contraseña temporal es <strong>{defaultPassword}</strong>. Cambíala
-        desde la página "Mi Perfil" cuando inicies sesión.
-      </p>
-      <Link href="/" className="button primary signin-btn">
-        <FiHome /> Ir al inicio
-      </Link>
-    </main>
+    <Layout>
+      <main className="register-page">
+        <h2>¡Registro exitoso!</h2>
+        <p className="subheading">
+          Tu contraseña temporal es <strong>{defaultPassword}</strong>. Cambíala
+          desde la página "Mi Perfil" cuando inicies sesión.
+        </p>
+        <Link href="/" className="button primary signin-btn">
+          <FiHome /> Ir al inicio
+        </Link>
+      </main>
+    </Layout>
   )
 }
 

--- a/pages/report-template.tsx
+++ b/pages/report-template.tsx
@@ -37,7 +37,7 @@ interface Props {
 
 const ReportTemplate: React.FC<Props> = ({ reportData, periodo, tipo }) => {
   return (
-    <div className="app-container" style={{ padding: '2rem' }}>
+    <div className="app-container main-content" style={{ padding: '2rem' }}>
       <h1 className="text-2xl font-bold mb-4">Informe de Solicitudes</h1>
       <p className="text-sm text-gray-600 mb-6">
         Periodo: {periodo} (de {reportData.meta.fechaInicio} a {reportData.meta.fechaFin})

--- a/pages/solicitudes/index.tsx
+++ b/pages/solicitudes/index.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from "axios";
 import { RequestForm } from "../../components/RequestForm";
+import Layout from "../../components/Layout";
 
 export default function SolicitudesPage() {
   const { data: items } = useQuery({
@@ -18,7 +19,8 @@ export default function SolicitudesPage() {
   };
 
   return (
-    <div>
+    <Layout>
+      <div className="main-content">
       <h1>Crear Solicitud</h1>
       <RequestForm items={items || []} />
 
@@ -60,6 +62,7 @@ export default function SolicitudesPage() {
           ))}
         </tbody>
       </table>
-    </div>
+      </div>
+    </Layout>
   );
 }


### PR DESCRIPTION
## Summary
- wrap standalone pages in `Layout` for consistent spacing
- mark report template container with `.main-content`
- handle edge cases in admin informes page
- drop extra header/footer from Dashboard component

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6888f31d48508327af1f382853c4c123