### PR TITLE
Center page content

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -20,6 +20,8 @@ export default function Layout({ children }: Props) {
   }, [router]);
   if (status === 'loading') return null;
 
+  const isHome = router.pathname === '/';
+
   const user = session?.user as { rol?: string; name?: string };
   const isAdmin = user?.rol === 'ADMIN';
   const logoHref = isAdmin ? '/admin' : '/';
@@ -123,7 +125,7 @@ export default function Layout({ children }: Props) {
           </div>
         </header>
       )}
-      <main className="main-content">{children}</main>
+      <main className={`main-content${isHome ? '' : ' page-center'}`}>{children}</main>
       <footer>
         <div className="app-container footer-flex">
           <span>© {new Date().getFullYear()} UNPHU – Inventario</span>

--- a/styles/global.css
+++ b/styles/global.css
@@ -575,6 +575,14 @@ footer {
   padding-bottom: var(--footer-height);
 }
 
+.page-center {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
 /* ==========================================================================
    13) RESPONSIVE
    ========================================================================== */


### PR DESCRIPTION
## Summary
- center content across pages using CSS
- apply centered style in layout except home page

## Testing
- `npm run build` *(fails: prisma not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888f5e0dacc832794dbc88d8579f831