### PR TITLE
Fix layout cropping on audit page

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -4,9 +4,9 @@ import Link from 'next/link';
 import { useSession, signOut } from 'next-auth/react';
 import { useRouter } from 'next/router';
 
-type Props = { children: ReactNode };
+type Props = { children: ReactNode; center?: boolean };
 
-export default function Layout({ children }: Props) {
+export default function Layout({ children, center = false }: Props) {
   const { data: session, status } = useSession();
   const router = useRouter();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -19,8 +19,6 @@ export default function Layout({ children }: Props) {
     };
   }, [router]);
   if (status === 'loading') return null;
-
-  const isHome = router.pathname === '/';
 
   const user = session?.user as { rol?: string; name?: string };
   const isAdmin = user?.rol === 'ADMIN';
@@ -125,7 +123,7 @@ export default function Layout({ children }: Props) {
           </div>
         </header>
       )}
-      <main className={`main-content${isHome ? '' : ' page-center'}`}>{children}</main>
+      <main className={`main-content${center ? ' page-center' : ''}`}>{children}</main>
       <footer>
         <div className="app-container footer-flex">
           <span>© {new Date().getFullYear()} UNPHU – Inventario</span>


### PR DESCRIPTION
## Summary
- make Layout centering optional so pages like the audit log are not vertically centered

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6888e5044d408327b614def4969d552b